### PR TITLE
Update 2026 02

### DIFF
--- a/BigWigs.toc
+++ b/BigWigs.toc
@@ -1,8 +1,8 @@
 ## Interface: 11200
 
-## X-Revision: 30134
+## X-Revision: 30135
 ## X-Fork: Pepo
-## Title: |cFFFF8080Pepopo|r Big Wigs |cff7fff7f30134|r |cffabd473Turtle-WoW|r
+## Title: |cFFFF8080Pepopo|r Big Wigs |cff7fff7f30135|r |cffabd473Turtle-WoW|r
 ## Title-zhCN: |cffabd473Turtle-WoW|r Big Wigs
 ## Notes: Boss Mods with Timer bars.
 ## Notes-esES: Módulos para Jefes con barras temporizadoras.

--- a/Core.lua
+++ b/Core.lua
@@ -84,13 +84,25 @@ L:RegisterTranslations("enUS", function()
 		["Alterac Valley"] = true,
 		["Arathi Basin"] = true,
 
-		--Name for exception bosses (neutrals that enable modules)
+		-- Name for exception bosses (neutrals that enable modules)
 		["Vaelastrasz the Corrupt"] = true,
 		["Lord Victor Nefarius"] = true,
 		["Solnius"] = true,
 		["Lieutenant General Andorov"] = true,
 
 		["You have slain %s!"] = true,
+
+		-- Raid Marks
+		["Star"] = true,
+		["Circle"] = true,
+		["Diamond"] = true,
+		["Triangle"] = true,
+		["Moon"] = true,
+		["Square"] = true,
+		["Cross"] = true,
+		["Skull"] = true,
+		["none"] = true,
+		["unmarked"] = true,
 	}
 end)
 
@@ -155,6 +167,18 @@ L:RegisterTranslations("esES", function()
 		["Lord Victor Nefarius"] = "Lord Victor Nefarius",
 
 		["You have slain %s!"] = "¡Has matado %s!",
+
+		-- Raid Marks
+		["Star"] = "Estrella",
+		["Circle"] = "Círculo",
+		["Diamond"] = "Diamante",
+		["Triangle"] = "Triángulo",
+		["Moon"] = "Luna",
+		["Square"] = "Cuadrado",
+		["Cross"] = "Cruz",
+		["Skull"] = "Cráneo",
+		["none"] = "ninguna",
+		["unmarked"] = "sin marcar",
 	}
 end)
 
@@ -209,6 +233,18 @@ L:RegisterTranslations("deDE", function()
 		-- ["Outdoor Raid Bosses Zone"] = "Outdoor Raid Bosses", -- DO NOT EVER TRANSLATE untill I find a more elegant option
 
 		["You have slain %s!"] = "Ihr habt %s getötet!",
+
+		-- Raid Marks
+		["Star"] = "Stern",
+		["Circle"] = "Kreis",
+		["Diamond"] = "Raute",
+		["Triangle"] = "Dreieck",
+		["Moon"] = "Mond",
+		["Square"] = "Quadrat",
+		["Cross"] = "Kreuz",
+		["Skull"] = "Schädel",
+		["none"] = "keine",
+		["unmarked"] = "unmarkiert",
 	}
 end)
 
@@ -498,6 +534,11 @@ function BigWigs.modulePrototype:SetRaidTargetForPlayer(player, mark)
 		self.storedPlayerMarks = {}
 	end
 	self.storedPlayerMarks[player] = previousMark
+
+	-- look up mark index if name string was input
+	if type(mark) == "string" then
+		mark = BigWigs:RaidTargetLookup(mark)
+	end
 
 	SetRaidTarget(playerUnit, mark)
 	return true
@@ -867,11 +908,17 @@ function BigWigs.modulePrototype:CancelDelayedMessage(text)
 	self:CancelScheduledEvent(delayPrefix .. "Message" .. self:ToString() .. text)
 end
 
-function BigWigs.modulePrototype:Bar(text, time, icon, otherColor, c1, c2, c3, c4, c5, c6, c7, c8, c9, c10)
-	self:TriggerEvent("BigWigs_StartBar", self, text, time, "Interface\\Icons\\" .. icon, otherColor, c1, c2, c3, c4, c5, c6, c7, c8, c9, c10)
+function BigWigs.modulePrototype:Bar(text, time, icon, otherColor, c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, emphasize, target, spell)
+	self:TriggerEvent("BigWigs_StartBar", self, text, time, "Interface\\Icons\\" .. icon, otherColor, c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, emphasize, target, spell)
 end
 function BigWigs.modulePrototype:RemoveBar(text)
 	self:TriggerEvent("BigWigs_StopBar", self, text)
+end
+function BigWigs.modulePrototype:DelayedBar(delay, text, time, icon, otherColor, c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, emphasize, target, spell)
+	return self:ScheduleEvent(delayPrefix .. "Bar" .. self:ToString() .. text, "BigWigs_StartBar", delay, self, text, time, "Interface\\Icons\\" .. icon, otherColor, c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, emphasize, target, spell)
+end
+function BigWigs.modulePrototype:CancelDelayedBar(text)
+	self:CancelScheduledEvent(delayPrefix .. "Bar" .. self:ToString() .. text)
 end
 
 function BigWigs.modulePrototype:IntervalBar(text, intervalMin, intervalMax, icon, otherColor, c1, c2, c3, c4, c5, c6, c7, c8, c9, c10)
@@ -881,12 +928,20 @@ function BigWigs.modulePrototype:DelayedIntervalBar(delay, text, intervalMin, in
 	return self:ScheduleEvent(delayPrefix .. "Bar" .. self:ToString() .. text, "BigWigs_StartIntervalBar", delay, self, text, intervalMin, intervalMax, "Interface\\Icons\\" .. icon, otherColor, c1, c2, c3, c4, c5, c6, c7, c8, c9, c10)
 end
 
-function BigWigs.modulePrototype:DelayedBar(delay, text, time, icon, otherColor, c1, c2, c3, c4, c5, c6, c7, c8, c9, c10)
-	return self:ScheduleEvent(delayPrefix .. "Bar" .. self:ToString() .. text, "BigWigs_StartBar", delay, self, text, time, "Interface\\Icons\\" .. icon, otherColor, c1, c2, c3, c4, c5, c6, c7, c8, c9, c10)
+function BigWigs.modulePrototype:ClickBar(text, time, icon, target, spell, otherColor, c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, emphasize)
+	self:TriggerEvent("BigWigs_StartBar", self, text, time, "Interface\\Icons\\" .. icon, otherColor, c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, emphasize, target, spell)
 end
-function BigWigs.modulePrototype:CancelDelayedBar(text)
-	self:CancelScheduledEvent(delayPrefix .. "Bar" .. self:ToString() .. text)
+function BigWigs.modulePrototype:DelayedClickBar(delay, text, time, icon, target, spell, otherColor, c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, emphasize)
+	return self:ScheduleEvent(delayPrefix .. "Bar" .. self:ToString() .. text, "BigWigs_StartBar", delay, self, text, time, "Interface\\Icons\\" .. icon, otherColor, c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, emphasize, target, spell)
 end
+
+function BigWigs.modulePrototype:MonitorBar(barName, icon, guid, type, displayText, insertMark, emphazise, otherColor, c1, c2, c3, c4, c5, c6, c7, c8, c9, c10)
+	self:TriggerEvent("BigWigs_StartMonitorBar", self, barName, "Interface\\Icons\\" .. icon, guid, type, displayText, insertMark, emphazise, otherColor, c1, c2, c3, c4, c5, c6, c7, c8, c9, c10)
+end
+function BigWigs.modulePrototype:DelayedMonitorBar(delay, barName, icon, guid, type, displayText, insertMark, emphazise, otherColor, c1, c2, c3, c4, c5, c6, c7, c8, c9, c10)
+	return self:ScheduleEvent(delayPrefix .. "Bar" .. self:ToString() .. barName, "BigWigs_StartMonitorBar", delay, self, barName, "Interface\\Icons\\" .. icon, guid, type, displayText, insertMark, emphazise, otherColor, c1, c2, c3, c4, c5, c6, c7, c8, c9, c10)
+end
+
 function BigWigs.modulePrototype:BarStatus(text)
 	local registered, time, elapsed, running = BigWigsBars:GetBarStatus(self, text)
 	return registered, time, elapsed, running
@@ -895,14 +950,12 @@ end
 function BigWigs.modulePrototype:Sound(sound)
 	self:TriggerEvent("BigWigs_Sound", sound)
 end
-
 function BigWigs.modulePrototype:DelayedSound(delay, sound, id)
 	if not id then
 		id = "_"
 	end
 	return self:ScheduleEvent(delayPrefix .. "Sound" .. self:ToString() .. sound .. id, "BigWigs_Sound", delay, sound)
 end
-
 function BigWigs.modulePrototype:CancelDelayedSound(sound, id)
 	if not id then
 		id = "_"
@@ -1563,5 +1616,109 @@ function BigWigs:BuffNameByIndex(buffIndex)
 	end
 end
 -- /run local i=0 DEFAULT_CHAT_FRAME:AddMessage("Buff "..(i+1)..": "..BigWigs:BuffNameByIndex(i))
+
+
+function BigWigs:GetUnitIdByName(name, depth)
+	depth = depth or 0 -- default to raid members
+	local suffix = ""
+	for i = 1,depth do
+		suffix = suffix .. "target"
+	end
+
+	--iterate over the raid and check the specified depth for a name match
+	for i = 1, GetNumRaidMembers() do
+		local id = "raid" .. i .. suffix
+		if UnitName(id) == name then
+			return id
+		end
+	end
+end
+
+function BigWigs:GetTargetByName(name, depth)
+	depth = depth or 1 -- default to targets of raid members
+	local unitId = BigWigs:GetUnitIdByName(name, depth)
+	if unitId then 
+		local target = UnitName(unitId.."target")
+		return target
+	end
+end
+
+function BigWigs:GetGUIDByName(name, depth, ignoredGUIDs)
+	depth = depth or 1 -- default to targets of raid members
+	local suffix = ""
+	for i = 1,depth do
+		suffix = suffix .. "target"
+	end
+
+	--iterate over the raid and check the specified depth for a name match
+	for i = 1, GetNumRaidMembers() do
+		local id = "raid" .. i .. suffix
+		if UnitName(id) == name then
+			local _, targetGUID = UnitExists(id)
+			-- name matched, now check exclusion list
+			if type(ignoredGUIDs) == "table" then
+				for _, excludedGUID in pairs(ignoredGUIDs) do
+					if targetGUID == excludedGUID then
+						targetGUID = nil
+						break
+					end
+				end
+			end
+			if targetGUID then
+				return targetGUID
+			end
+		end
+	end
+end
+
+function BigWigs:OffsetGUID(input, offset)
+	local max = 4294967295 -- 32 bit limitation of tonumber and string.format
+	local prefix, highInput, lowInput = string.sub(input,1,-17), string.sub(input,-16,-9), string.sub(input,-8)
+
+	local lowOutput = tonumber(lowInput,16) + offset
+	local highOutput = tonumber(highInput,16)
+	if lowOutput < 0 then
+		lowOutput = lowOutput + max + 1
+		highOutput = highOutput - 1
+	elseif lowOutput > max then
+		lowOutput = lowOutput - max - 1
+		highOutput = highOutput + 1
+	end
+
+	return prefix..string.format("%08X",highOutput)..string.format("%08X",lowOutput)
+end
+
+function BigWigs:RaidTargetLookup(input)
+	local raidTargets = {
+		[0] = "none", -- following pattern of SetRaidTarget()
+		[1] = "Star",
+		[2] = "Circle",
+		[3] = "Diamond",
+		[4] = "Triangle",
+		[5] = "Moon",
+		[6] = "Square",
+		[7] = "Cross",
+		[8] = "Skull"
+	}
+
+	-- convert index to name
+	if type(input) == "number" then
+		local output = raidTargets[input]
+		if output then return L[output] end --localize output for displaying
+
+	-- convert name to index
+	elseif type(input) == "string" then
+		input = string.lower(input)
+		for i=0,8 do
+			if input == string.lower(raidTargets[i]) then
+				return i
+			end
+		end
+
+	-- nil means unmarked following pattern of GetRaidTargetIndex()
+	elseif type(input) == "nil" then
+		return L["unmarked"]
+	end
+end
 
 

--- a/Plugins/Bars.lua
+++ b/Plugins/Bars.lua
@@ -81,6 +81,9 @@ L:RegisterTranslations("enUS", function()
 		["Emphasize Bars"] = true,
 		["Enable IntervalBars"] = true,
 		["Keep timers visible untill the timed event happens"] = true,
+		["HP"] = true,
+		["Mana"] = true,
+		["dead"] = true,
 	}
 end)
 
@@ -120,6 +123,9 @@ L:RegisterTranslations("deDE", function()
 		["Move bars that are emphasized to a second anchor."] = "Hervorgehobene Anzeigebalken zu einem zweiten Ankerpunkt bewegen.",
 		["Set the scale for emphasized bars."] = "Die Skalierung für hervorgehobene Anzeigebalken festlegen.",
 		["Emphasize Bars"] = "Hervorgehobene Balken",
+		["HP"] = "HP",
+		["Mana"] = "Mana",
+		["dead"] = "tot",
 	}
 end)
 
@@ -161,6 +167,9 @@ L:RegisterTranslations("esES", function()
 		["Emphasize Bars"] = "Barras de Alerta",
 		["Enable IntervalBars"] = "Activar las Barras de Intervalo",
 		["Keep timers visible untill the timed event happens"] = "Se queda visibles los temporizadores hasta que un evento medido occura",
+		["HP"] = "HP",
+		["Mana"] = "Mana",
+		["dead"] = "muerto",
 	}
 end)
 ----------------------------------
@@ -438,6 +447,7 @@ function BigWigsBars:OnEnable()
 	self:RegisterEvent("BigWigs_StopHPBar")
 	self:RegisterEvent("BigWigs_SetHPBar")
 	self:RegisterEvent("BigWigs_StartIntervalBar")
+	self:RegisterEvent("BigWigs_StartMonitorBar")
 	if not self:IsEventRegistered("Surface_Registered") then
 		self:RegisterEvent("Surface_Registered", function()
 			self.consoleOptions.args[L["Texture"]].validate = surface:List()
@@ -537,11 +547,12 @@ function BigWigsBars:BigWigs_HideAnchors()
 	end
 end
 
-function BigWigsBars:BigWigs_StartBar(module, text, time, icon, otherc, c1, c2, c3, c4, c5, c6, c7, c8, c9, c10)
+function BigWigsBars:BigWigs_StartBar(module, text, time, icon, otherc, c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, emphasize, target, spell)
 	if not text or not time then
 		return
 	end
 	local id = "BigWigsBar " .. text
+	if emphasize == nil then emphasize = true end
 	if not self.frames.anchor then
 		self:SetupFrames()
 	end
@@ -562,7 +573,7 @@ function BigWigsBars:BigWigs_StartBar(module, text, time, icon, otherc, c1, c2, 
 
 	local groupId = self.frames.anchor.candyBarGroupId
 	local scale = self.db.profile.scale or 1
-	if self.frames.emphasizeAnchor and self.db.profile.emphasize and (self.db.profile.emphasizeMove or self.db.profile.emphasizeFlash) then
+	if self.frames.emphasizeAnchor and self.db.profile.emphasize and emphasize == true and (self.db.profile.emphasizeMove or self.db.profile.emphasizeFlash) then
 		-- If the bar is started at more than 15 seconds, it won't be emphasized
 		-- right away, but if it's started at 15 or less, it will be.
 		if time > 20 then
@@ -669,6 +680,29 @@ function BigWigsBars:BigWigs_StartBar(module, text, time, icon, otherc, c1, c2, 
 			elseif IsShiftKeyDown() then
 				SendChatMessage(text .. " in " .. SecondsToTime(math.floor(t - elapsed)), "RAID");
 				SendChatMessage(text .. " in " .. SecondsToTime(math.floor(t - elapsed)), "BATTLEGROUND");
+			else
+				if target and spell and SUPERWOW_VERSION then
+					-- SuperWoW can cast without retargeting if we can get a GUID
+					local superTarget = target
+					if string.sub(target,1,2) ~= "0x" then
+						superTarget = BigWigs:GetGUIDByName(target, 0) or BigWigs:GetGUIDByName(target, 1)
+					end
+					if superTarget then
+						CastSpellByName(spell, superTarget)
+						return
+					end
+				end
+				-- normal target & cast, also SuperWoW fall-back if no GUID found
+				if target then
+					if string.sub(target,1,2) == "0x" then -- GUID
+						TargetUnit(target)
+					else -- name
+						TargetByName(target,true)
+					end
+				end
+				if spell then
+					CastSpellByName(spell)
+				end
 			end
 		end
 	end
@@ -767,12 +801,12 @@ function BigWigsBars:BigWigs_HideCounterBars()
 	counterBarCache = {}
 end
 
-function BigWigsBars:BigWigs_StartHPBar(module, text, max, bar, icon, c1, c2, c3, c4, c5, c6, c7, c8, c9, c10)
+function BigWigsBars:BigWigs_StartHPBar(module, text, max, icon, otherc, c1, c2, c3, c4, c5, c6, c7, c8, c9, c10)
 	if not text then
 		return
 	end
 	local id = "BigWigsBar " .. text
-	BigWigsBars:BigWigs_StartBar(module, text, max, bar, icon, c1, c2, c3, c4, c5, c6, c7, c8, c9, c10)
+	BigWigsBars:BigWigs_StartBar(module, text, max, icon, otherc, c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, false)
 	module:PauseCandyBar(id)
 	module:SetCandyBarTimeFormat(id, function(t)
 		local timetext
@@ -815,6 +849,99 @@ function BigWigsBars:BigWigs_StartIntervalBar(module, text, intervalMin, interva
 	if self.db.profile.intervalbar then
 		self:SetCandyBarFade("BigWigsBar " .. text, intervalMax - intervalMin)
 	end
+end
+
+local monitorBarCache = {-- [i] = {barName, GUID, type, barText, insertMark}
+}
+function BigWigsBars:BigWigs_StartMonitorBar(module, barName, icon, guid, type, displayText, insertMark, emphazise, otherc, c1, c2, c3, c4, c5, c6, c7, c8, c9, c10)
+	if (not barName) or (not guid) then
+		return
+	end
+	
+	-- set up defaults
+	type = type or "health"
+	displayText = displayText or ""
+	if emphazise == nil then
+		emphazise = false
+	end
+	if not otherc then
+		otherc = true
+		c1 = (type == "health" and "Green") or (type == "mana" and "Blue")
+	end
+	
+	-- create bar, pause it, format timer
+	BigWigsBars:BigWigs_StartBar(module, barName, 100, icon, otherc, c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, emphazise, guid)
+	local id = "BigWigsBar " .. barName
+	module:PauseCandyBar(id)
+	module:SetCandyBarTimeFormat(id, function(t)
+		return string.format("%d%%", floor(t))
+	end)
+
+
+	local barExists = false
+	for i = 1, table.getn(monitorBarCache) do
+		if monitorBarCache[i] and monitorBarCache[i][1] == barName then
+			barExists = true
+			monitorBarCache[i][2] = guid
+			monitorBarCache[i][3] = type
+			monitorBarCache[i][4] = displayText
+			monitorBarCache[i][5] = insertMark
+		end
+	end
+	if not barExists then
+		table.insert(monitorBarCache, { barName, guid, type, displayText, insertMark })
+	end
+
+	BigWigsBars:UpdateAllMonitorBars()
+end
+
+function BigWigsBars:UpdateAllMonitorBars()
+	if table.getn(monitorBarCache) == 0 then
+		return
+	end
+
+	for i = 1,table.getn(monitorBarCache) do
+		local id = "BigWigsBar " .. monitorBarCache[i][1]
+		local bar = candybar.var.handlers[id]
+		if not bar then
+			table.remove(monitorBarCache, i)
+			self:UpdateAllMonitorBars()
+			return
+		end
+
+		-- check unit for health or mana
+		local currentValue = 0
+		local currentValueString = ""
+		local currentPercent = 0
+		if monitorBarCache[i][3] == "health" and UnitExists(monitorBarCache[i][2]) then
+			currentValue = UnitHealth(monitorBarCache[i][2])
+			currentValueString = currentValue.." "..L["HP"]
+			currentPercent = math.floor(currentValue/UnitHealthMax(monitorBarCache[i][2]) * 100)
+		elseif monitorBarCache[i][3] == "mana" and UnitExists(monitorBarCache[i][2]) then
+			currentValue = UnitMana(monitorBarCache[i][2])
+			currentValueString = currentValue.." "..L["Mana"]
+			currentPercent = math.floor(currentValue/UnitManaMax(monitorBarCache[i][2]) * 100)
+		end
+		-- update bar
+		bar.elapsed = 100 - currentPercent
+		candybar:Update(id)
+
+		-- piece together new bar text
+		local assembledText = monitorBarCache[i][4]
+		if monitorBarCache[i][5] == true and UnitExists(monitorBarCache[i][2]) then
+			assembledText = assembledText.." "..BigWigs:RaidTargetLookup(GetRaidTargetIndex(monitorBarCache[i][2]))
+		end
+		if UnitExists(monitorBarCache[i][2]) and not UnitIsDead(monitorBarCache[i][2]) then
+			assembledText = assembledText.." - "..currentValueString
+		else
+			assembledText = assembledText.." - "..L["dead"]
+		end
+		-- update bar
+		candybar:SetText(id, assembledText)
+	end
+
+	-- check again in quarter of a second; non-repeatable so it auto-cancels if bar cache is empty
+	self:ScheduleEvent("UpdateMonitorBars", self.UpdateAllMonitorBars, 0.25, self)
 end
 
 -----------------------------------------------------------------------

--- a/Plugins/CommonAuras.lua
+++ b/Plugins/CommonAuras.lua
@@ -785,58 +785,37 @@ function BigWigsCommonAuras:BigWigs_RecvSync(sync, rest, nick)
 			swTime = 10
 		end -- If the tank uses an old BWCA, just assume 10 seconds.
 		self:TriggerEvent("BigWigs_Message", nick .. L["msg_shieldwall"], "Urgent", false, nil, false)
-		self:TriggerEvent("BigWigs_StartBar", self, nick .. L["bar_shieldwall"], swTime, icon.shieldwall, true, color.shieldwall)
-		self:SetCandyBarOnClick("BigWigsBar " .. nick .. L["bar_shieldwall"], function(name, button, extra)
-			TargetByName(extra, true)
-		end, nick)
+		self:TriggerEvent("BigWigs_StartBar", self, nick .. L["bar_shieldwall"], swTime, icon.shieldwall, true, color.shieldwall, nil, nil, nil, nil, nil, nil, nil, nil, nil, true, nick, false)
 
 
 	elseif self.db.profile.laststand and sync == "BWCALS" then
 		self:TriggerEvent("BigWigs_Message", nick .. L["msg_laststand"], "Urgent", false, nil, false)
-		self:TriggerEvent("BigWigs_StartBar", self, nick .. L["bar_laststand"], timer.laststand, icon.laststand, true, color.laststand)
-		self:SetCandyBarOnClick("BigWigsBar " .. nick .. L["bar_laststand"], function(name, button, extra)
-			TargetByName(extra, true)
-		end, nick)
+		self:TriggerEvent("BigWigs_StartBar", self, nick .. L["bar_laststand"], timer.laststand, icon.laststand, true, color.laststand, nil, nil, nil, nil, nil, nil, nil, nil, nil, true, nick, false)
 
 
 	elseif self.db.profile.lifegivinggem and sync == "BWCALG" then
 		self:TriggerEvent("BigWigs_Message", nick .. L["msg_lifegivingGem"], "Urgent", false, nil, false)
-		self:TriggerEvent("BigWigs_StartBar", self, nick .. L["bar_lifegivingGem"], timer.lifegivingGem, icon.lifegivingGem, true, color.lifegivingGem)
-		self:SetCandyBarOnClick("BigWigsBar " .. nick .. L["bar_lifegivingGem"], function(name, button, extra)
-			TargetByName(extra, true)
-		end, nick)
+		self:TriggerEvent("BigWigs_StartBar", self, nick .. L["bar_lifegivingGem"], timer.lifegivingGem, icon.lifegivingGem, true, color.lifegivingGem, nil, nil, nil, nil, nil, nil, nil, nil, nil, true, nick, false)
 
 
 	elseif self.db.profile.challengingshout and sync == "BWCACS" then
 		self:TriggerEvent("BigWigs_Message", nick .. L["msg_challengingShout"], "Urgent", false, nil, false)
-		self:TriggerEvent("BigWigs_StartBar", self, nick .. L["bar_challengingShout"], timer.challenging, icon.challengingShout, true, color.challengingShout)
-		self:SetCandyBarOnClick("BigWigsBar " .. nick .. L["bar_challengingShout"], function(name, button, extra)
-			TargetByName(extra, true)
-		end, nick)
+		self:TriggerEvent("BigWigs_StartBar", self, nick .. L["bar_challengingShout"], timer.challenging, icon.challengingShout, true, color.challengingShout, nil, nil, nil, nil, nil, nil, nil, nil, nil, true, nick, false)
 
 
 	elseif self.db.profile.challengingroar and sync == "BWCACR" then
 		self:TriggerEvent("BigWigs_Message", nick .. L["msg_challengingRoar"], "Urgent", false, nil, false)
-		self:TriggerEvent("BigWigs_StartBar", self, nick .. L["bar_challengingRoar"], timer.challenging, icon.challengingRoar, true, color.challengingRoar)
-		self:SetCandyBarOnClick("BigWigsBar " .. nick .. L["bar_challengingRoar"], function(name, button, extra)
-			TargetByName(extra, true)
-		end, nick)
+		self:TriggerEvent("BigWigs_StartBar", self, nick .. L["bar_challengingRoar"], timer.challenging, icon.challengingRoar, true, color.challengingRoar, nil, nil, nil, nil, nil, nil, nil, nil, nil, true, nick, false)
 
 
 	elseif self.db.profile.spiritlink and sync == "BWCASL" and rest then
 		-- self:TriggerEvent("BigWigs_Message", L["msg_spiritLink"] .. rest, "Important", false, nil, false) -- noise
 		self:TriggerEvent("BigWigs_Sound", "Info")
-		self:TriggerEvent("BigWigs_StartBar", self, rest .. L["bar_spiritLink"], timer.spiritLink, icon.spiritLink, true, color.spiritLink)
-		self:SetCandyBarOnClick("BigWigsBar " .. rest .. L["bar_spiritLink"], function(name, button, extra)
-			TargetByName(extra, true)
-		end, rest)
+		self:TriggerEvent("BigWigs_StartBar", self, rest .. L["bar_spiritLink"], timer.spiritLink, icon.spiritLink, true, color.spiritLink, nil, nil, nil, nil, nil, nil, nil, nil, nil, true, nick, false)
 
 	elseif self.db.profile.di and sync == "BWCADI" then
 		self:TriggerEvent("BigWigs_Message", L["msg_divineIntervention"] .. nick, "Urgent", false, nil, false)
 		self:TriggerEvent("BigWigs_StartBar", self, nick .. L["bar_divineIntervention"], timer.di, icon.di, true, color.di)
-		self:SetCandyBarOnClick("BigWigsBar " .. nick .. L["bar_divineIntervention"], function(name, button, extra)
-			TargetByName(extra, true)
-		end, nick)
 
 	elseif self.db.profile.portal and sync == "BWCAP" and rest then
 		rest = BS:HasTranslation(rest) and BS:GetTranslation(rest) or rest

--- a/Plugins/Farclip.lua
+++ b/Plugins/Farclip.lua
@@ -25,6 +25,7 @@ L:RegisterTranslations("enUS", function()
 		["Raid farclip value"] = "Value to set farclip to in Naxx/Kara",
 		["lowering_farclip"] = "Lowering farclip for %s to %d and saving your current farclip of %d.  You can configure this in the Farclip plugin in BigWigs.",
 		["restoring_farclip"] = "Restoring lowered farclip to your saved value of %d.",
+		["low_spell_effects"] = "WARNING: Spell Effect Level is set to %d. Certain boss effects like void/pink zones may be hard or impossible to see. Click the bar to raise it, or type: /script SetCVar(\"spellEffectLevel\", \"2\")",
 	}
 end)
 
@@ -158,6 +159,18 @@ function BigWigsFarclip:ZONE_CHANGED_NEW_AREA()
 				self.db.profile.defaultFarclip = GetCVar("farclip")
 				SetCVar("farclip", self.db.profile.lowFarClip) -- http://wowwiki.wikia.com/wiki/CVar_farclip
 			end
+			local spellEffectLevel = tonumber(GetCVar("spellEffectLevel")) or 2
+			if spellEffectLevel < 2 then
+				local spellEffectMsg = string.format(L["low_spell_effects"], spellEffectLevel)
+				self:Message(spellEffectMsg, "Red", false, nil, false)
+				DEFAULT_CHAT_FRAME:AddMessage("BIGWIGS: " .. spellEffectMsg, 1, 1, 0)
+				self:Bar(">CLICK ME< Set spellEffectLevel=2", 10, "Spell_Magic_LesserInvisibilty", true, "Red")
+				self:SetCandyBarOnClick("BigWigsBar >CLICK ME< Set spellEffectLevel=2", function()
+					SetCVar("spellEffectLevel", 2)
+					DEFAULT_CHAT_FRAME:AddMessage("BigWigs: spellEffectLevel set to " .. GetCVar("spellEffectLevel"), 0, 1, 0)
+					self:RemoveBar(">CLICK ME< Set spellEffectLevel=2")
+				end)
+			end
 	elseif self.db.profile.kara and isInKara() then
 		if not isAtLowFarclip then
 			if self.db.profile.notify then
@@ -167,6 +180,18 @@ function BigWigsFarclip:ZONE_CHANGED_NEW_AREA()
 
 			self.db.profile.defaultFarclip = GetCVar("farclip")
 			SetCVar("farclip", self.db.profile.lowFarClip) -- http://wowwiki.wikia.com/wiki/CVar_farclip
+		end
+		local spellEffectLevel = tonumber(GetCVar("spellEffectLevel")) or 2
+		if spellEffectLevel < 2 then
+			local spellEffectMsg = string.format(L["low_spell_effects"], spellEffectLevel)
+			self:Message(spellEffectMsg, "Red", false, nil, false)
+			DEFAULT_CHAT_FRAME:AddMessage("BIGWIGS: " .. spellEffectMsg, 1, 1, 0)
+			self:Bar(">CLICK ME< Set spellEffectLevel=2", 10, "Spell_Magic_LesserInvisibilty", true, "Red")
+			self:SetCandyBarOnClick("BigWigsBar >CLICK ME< Set spellEffectLevel=2", function()
+				SetCVar("spellEffectLevel", 2)
+				DEFAULT_CHAT_FRAME:AddMessage("BigWigs: spellEffectLevel set to " .. GetCVar("spellEffectLevel"), 0, 1, 0)
+				self:RemoveBar(">CLICK ME< Set spellEffectLevel=2")
+			end)
 		end
 	else
 		if isAtLowFarclip then

--- a/Plugins/SpellRequests.lua
+++ b/Plugins/SpellRequests.lua
@@ -65,6 +65,14 @@ local Spells = {
 		targetRequester = false,
 		allowRequests = true,
 	},
+	pws = {
+		spellName = "Power Word: Shield",
+		spellIcon = "Spell_Holy_PowerWordShield",
+		spellSlot = nil,
+		hasSpell = nil,
+		targetRequester = true,
+		allowRequests = true,
+	},
 	-- check cooldowns only
 	cshout = {
 		spellName = "Challenging Shout",

--- a/README.md
+++ b/README.md
@@ -1,26 +1,36 @@
 # BigWigs Golden Edition
 Big updates to K40 and MC (**check your boss settings!**), small fixes and updates here and there. Mostly tested.
+
+Updates are summarized in the [changelog](https://github.com/ElesionWoW/BigWigs/blob/master/documentation/changelog.txt). Details are in individual commits.
 ## Karazhan 40 - Highlights
 * Trash - many additional mobs and mechanics (including "don't move" and "don't cast")
 * Keeper - accurate Owl phase timer
-* Incantagos - Affinity auto-targeting, Surge of Mana victim bars, Blizzard warning
+* Incantagos - target Affinities automatically or by clicking on the timer bar, Surge of Mana victim bars, Blizzard warning
 * Anomalus - Floor Zone warnings
 * Echo - additional warnings, optional timers to align Resto Pot usage
 * Chess - accurate cast bars (hide, SBV), Curse CD (to allign hide phases)
-* Sanv - bar for add phase duration
-* Rupturan - alert when you stand in fire
+* Sanv - bar for add phase duration, warn about last Curse before Feedback
+* Rupturan - Boulder target warnings, P1 kill window, alert when you stand in fire, monitoring of Felheart mana
 * Mephistroth - Doom bar, purge alert, better Shards handling, sound cue on Shackle fade
 ## Other Feature Highlights
 * Announcing bars to /raid now requires a Shift-click to prevent accidental spam.
-* AQ40 - C'Thun map fix
-* Ragnaros - warn about tank knockback
+* AQ40 - C'Thun map fix, vastly improved monitoring of Stomach Tentacles
+* MC - warning about tank knockback at Ragnaros, improved information at Thaurissan
 * ZG & AQ20 - minor fixes
 * DM North - Kromcrush fixes, new Eye of Kilrogg module
 ## Future Ideas
+* ClickBar - Update more modules, add class-based CC options to all mind-control effects.
+* MonitorBar - Update more modules: Thekal (health), Moam (mana), Thaddius (health).
+* Mandokir & Buru - Properly fix rare concat errors.
+* Keeper Gnarlmoon - Identify Owls by location.
 * Chess - Keep track of major piece health and announce every % below 5.
-* Centralize bar OnClick behavior for targeting and spell casting (for easier setup and so custom bars can be right-clicked to cancel them).
-* A timer bar for temporary flying mounts.
-* A new bar type for mob HP.
+* Thaurissan - Are timer bars for Knockback CD feasible and helpful?
+* Rend Blackhand - Fix the event timer bars.
+* CommonAura plugin - Add a timer bar for temporary flying mounts.
+* CommonAura plugin - Add a timer bar for Tranquility from raid members.
+* CandyBar library - Potentially unregister Mouse4 and Mouse5 so they aren't captured anymore if the cursor happens to be above a bar.
+* CommonAura plugin - Look into the bug that some players sync numbers as their targets (eg Fear Ward bar).
+* Core - figure out a (non-SuperWoW) way to capture buffs/debuffs/stacks refreshing since it doesn't trigger a combat log entry.
 ## Karazhan 40 - Full Changelog
 Relative to pepopo978's BigWigs.
 ### General
@@ -44,12 +54,13 @@ Relative to pepopo978's BigWigs.
 * Added warning sign to Affinity summon.
 * Proximity window is now off by default.
 * Added Blizzard warning (default: on).
-* Added Affinity auto-targeting (default: off).
+* Added Affinity auto-targeting (default: off). Can also click the Affinity timer bar to target.
 * Shortened some overly verbose Affinity messages.
 * Added Berserk warning (always on).
 * Added personal bars for every Surge of Mana victim (default: on; click bar to target victim, if paladin also to cast Hand of Freedom), /say announcement by victims (default: on).
 * Keep track of initial Ley-Seeker adds and warn if any are alive when boss it at 85% HP (always on).
 * Based the initial CD bar for Ley-Line Disturbance on the death of the fourth add and shortened CD bar (lowest observed in logs is 45s instead of 55s).
+* Added cooldown bar for the next wave of summons (default: off) (idea by [DCV-2142](https://github.com/DCV-2142/BigWigs)).
 ### Anomalus
 * Added message on /raid when using Death Wish and dropping below 200 AR (always on).
 * Personal Arcane Overload (bomb) warnings will now always show. The Arcane Overload setting now only handles other players, skull marking, cooldown bars.
@@ -83,10 +94,17 @@ Relative to pepopo978's BigWigs.
 * Added alerts for Portal Opening and Enrage (always on).
 * Added timer bar for add phase (default: on).
 * Phase Shifted alerts now only trigger below 80% boss HP.
+* Added Curse cooldown (default: off) and Rift Feedback cooldown (default: off) bars (largely by [DCV-2142](https://github.com/DCV-2142/BigWigs)).
+* Added warning to the last Curse before a Rift Feedback (default: on).
 ### Rupturan
 * Added personal warning to move out of Ignite Rock flamestrike area (default: on).
 * Added Reform timers when Fragments are defeated (default: on).
 * Added alternate triggers to no longer depend on SuperWoW cast events.
+* Added Throw Boulder mechanic - warn about the current target (default: off), mark the current target with Moon (default: on), announce incoming Boulder and Boulder miss to /say if you are the target (default: on)
+* Added Window of Opportunity handling below 15% HP boss HP in phase 1 by keeping track of Living Stone spawns to avoid Explode (default: on).
+* Added alert for high Felheart mana (default: on).
+* Added Felheart mana bar (default: on for priests, warlocks, hunters).
+* Added Ignite Earth timers (P1 flamestrike; default: off) (idea by [DCV-2142](https://github.com/DCV-2142/BigWigs)).
 ### Mephistroth
 * Added duration bar for Doom (default: on for druid/mage, off for everyone else), which is clickable to decurse the current Doom victim.
 * Added purge alert for Vampiric Aura (default: on for shaman/priest, off for everyone else).
@@ -97,8 +115,23 @@ Relative to pepopo978's BigWigs.
 * Tattle option also prints to the default chat window.
 * Added alternate triggers to greatly reduce the reliance on SuperWoW cast events.
 * Added mark (default: on) and alert with sound cue (default: off) about the current Waking Nightmare target to indicate Crawler spawn point for OTs.
+* Added bars for minimum Shackles cooldown (default: on) and Fear cooldown (default: off) (largely by [DCV-2142](https://github.com/DCV-2142/BigWigs)).
 
 Kruul is unchanged for now.
+### Internal Changes
+Check out the documentation subfolder for further information on many features.
+* Full support for forking.
+* New helper functions added to Core: BuffNameByIndex(), GetUnitIdByName(), GetTargetByName(), GetGUIDByName(), OffsetGUID(), RaidTargetLookup().
+* Expanded Bars plugin to add emphasis toggle, streamlined OnClick handling, and a new dynamically updating MonitorBar.
+* Updated Babble-Zone and Babble-Boss libraries with TWoW custom names.
+### Design Principles for Contributing
+* Avoid relying on client mods. - Where possible provide alternate triggers that don't require client mods (like SuperWoW).
+* Give players options. - Create sensible and granular settings. If a feature is only relevant to few people, do still include it but default it to off.
+* Provide actionable information that is easy to parse. - BigWigs should serve relevant information in high-pressure situations without distracting users. Examples: For an alert "Run away - Corruption!" is better than "There is Corruption of Medivh on you, you should get out of the raid". For a bar text "Alice MC" is more helpful than "Chains of Kel'Thuzad on Alice". [sidenote: this is mostly for new features; for old features there is value in keeping alerts people have grown used to]
+* Calls to action should have sound cues. - Not everyone plays with sound, but those that do rely on it.
+* Field-test your updates. - Never push major updates that you haven't verified in-game.
+
+If you (broadly) heed those principles I do welcome well-crafted pull requests! But please be patient and don't expect immediate reactions. BigWigs is a low-priority project for me.
 
 # BigWigs (legacy description)
 BigWigs is a World of Warcraft AddOn to predict certain AI behaviour to improve the players performance.<br>

--- a/Raids/AQ40/Cthun.lua
+++ b/Raids/AQ40/Cthun.lua
@@ -28,7 +28,6 @@ module.defaultDB = {
 	mapY = 400,
 	mapAlpha = 1,
 	mapScale = 1,
-	autotarget = false,
 	window = false,
 }
 
@@ -142,9 +141,9 @@ L:RegisterTranslations("enUS", function()
 		trigger_digestiveAcid = "You are afflicted by Digestive Acid %((.+)%).", --CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE
 		msg_digestiveAcid = " Acid Stacks - Consider getting out of the Stomach",
 
-		hpBar_firstTentacle = "First Tentacle",
-		hpBar_secondTentacle = "Second Tentacle",
+		unit_fleshTentacle = "Flesh Tentacle",
 		msg_firstTentacleDead = "First Tentacle Dead",
+		msg_secondTentacleLow = "Second Tentacle at %s%% HP",
 
 		frameHeader_playersInStomach = "Players in Stomach",
 	}
@@ -197,7 +196,7 @@ local icon = {
 
 	digestiveAcid = "ability_creature_disease_02",
 
-	stomachTentacle = "inv_misc_ahnqirajtrinket_05",
+	stomachTentacle = "INV_Misc_AhnQirajTrinket_05",
 }
 local color = {
 	startRandomBeams = "Cyan",
@@ -243,6 +242,10 @@ local syncName = {
 
 	firstStomachTentacleDead = "CThunFleshTentacleDead2" .. module.revision,
 }
+local guid = {
+	stomachL = nil,
+	stomachR = nil,
+}
 
 module.proximityCheck = function(unit)
 	return CheckInteractDistance(unit, 2)
@@ -257,8 +260,6 @@ local lastEyeTarget = nil
 
 local firstStomachTentacleDead = nil
 local secondTentacleLowWarn = nil
-local firstTentacleHP = 100
-local secondTentacleHP = 100
 
 local smallEyeDead = 0
 local smallEyeDeadCounter = 8
@@ -328,8 +329,6 @@ function module:OnEngage()
 
 	firstStomachTentacleDead = nil
 	secondTentacleLowWarn = nil
-	firstTentacleHP = 100
-	secondTentacleHP = 100
 
 	smallEyeDead = 0
 	smallEyeDeadCounter = 8
@@ -382,7 +381,8 @@ function module:OnDisengage()
 	self:CancelScheduledEvent("CthunDarkGlare")
 	self:CancelScheduledEvent("CThunDelayedEyeBeamCheck")
 	self:CancelScheduledEvent("CthunCheckTarget")
-	self:CancelScheduledEvent("CThunCheckTentacleHP")
+	self:CancelScheduledEvent("CthunFindFleshTentacle")
+	self:CancelScheduledEvent("CthunCheckFleshTentacles")
 end
 
 function module:MINIMAP_ZONE_CHANGED(msg)
@@ -402,8 +402,6 @@ function module:ResetModule()
 
 	firstStomachTentacleDead = nil
 	secondTentacleLowWarn = nil
-	firstTentacleHP = 100
-	secondTentacleHP = 100
 
 	smallEyeDead = 0
 	smallEyeDeadCounter = 8
@@ -417,7 +415,8 @@ function module:ResetModule()
 	self:CancelScheduledEvent("CthunDarkGlare")
 	self:CancelScheduledEvent("CThunDelayedEyeBeamCheck")
 	self:CancelScheduledEvent("CthunCheckTarget")
-	self:CancelScheduledEvent("CThunCheckTentacleHP")
+	self:CancelScheduledEvent("CthunFindFleshTentacle")
+	self:CancelScheduledEvent("CthunCheckFleshTentacles")
 end
 
 function module:CHAT_MSG_COMBAT_HOSTILE_DEATH(msg)
@@ -432,7 +431,7 @@ function module:CHAT_MSG_COMBAT_HOSTILE_DEATH(msg)
 	elseif (msg == string.format(UNITDIESOTHER, "Giant Eye Tentacle")) then
 		self:Sync(syncName.window)
 
-	elseif (msg == string.format(UNITDIESOTHER, "Flesh Tentacle")) and not firstStomachTentacleDead then
+	elseif (msg == string.format(UNITDIESOTHER, L["unit_fleshTentacle"])) and not firstStomachTentacleDead then
 		self:Sync(syncName.firstStomachTentacleDead)
 
 	elseif (msg == string.format(UNITDIESOTHER, "Eye Tentacle")) then
@@ -456,45 +455,6 @@ function module:CHAT_MSG_MONSTER_EMOTE(msg)
 		self:Sync(syncName.weakened)
 	end
 end
-
---[[
-function module:UNIT_HEALTH(msg)
-	if UnitName(msg) == "Flesh Tentacle" then
-		local healthPct = UnitHealth(msg) * 100 / UnitHealthMax(msg)
-
-		if secondTentacleLowWarn == true and healthPct >= 20 then
-			secondTentacleLowWarn = nil
-			firstTentacleHP = 1
-			secondTentacleHP = 100
-			self:TriggerEvent("BigWigs_SetHPBar", self, L["hpBar_firstTentacle"], 100 - firstTentacleHP)
-			self:TriggerEvent("BigWigs_SetHPBar", self, L["hpBar_secondTentacle"], 100 - secondTentacleHP)
-		end
-
-		if not firstStomachTentacleDead then
-			if healthPct < firstTentacleHP then
-				firstTentacleHP = healthPct
-				self:TriggerEvent("BigWigs_SetHPBar", self, L["hpBar_firstTentacle"], 100 - firstTentacleHP)
-				self:TriggerEvent("BigWigs_SetHPBar", self, L["hpBar_secondTentacle"], 100 - secondTentacleHP)
-			elseif healthPct > firstTentacleHP and healthPct < secondTentacleHP then
-				secondTentacleHP = healthPct
-				self:TriggerEvent("BigWigs_SetHPBar", self, L["hpBar_firstTentacle"], 100 - firstTentacleHP)
-				self:TriggerEvent("BigWigs_SetHPBar", self, L["hpBar_secondTentacle"], 100 - secondTentacleHP)
-			end
-		elseif firstStomachTentacleDead then
-			firstTentacleHP = 1
-			if healthPct < secondTentacleHP then
-				secondTentacleHP = healthPct
-				self:TriggerEvent("BigWigs_SetHPBar", self, L["hpBar_firstTentacle"], 100 - firstTentacleHP)
-				self:TriggerEvent("BigWigs_SetHPBar", self, L["hpBar_secondTentacle"], 100 - secondTentacleHP)
-			end
-			if secondTentacleHP <= 20 and not secondTentacleLowWarn then
-				self:Message("Second Tentacle at "..secondTentacleHP.."% HP")
-				secondTentacleLowWarn = true
-			end
-		end
-	end
-end
-]]--
 
 function module:Event(msg)
 	if msg == L["trigger_cthun_eyeBeam"] then
@@ -603,6 +563,7 @@ function module:DelayedEyeBeamCheck()
 		self:Bar(L["bar_eyeBeam"] .. name, timer.eyeBeamCast - 0.1, icon.giantEye, true, color.eyeBeam)
 	end
 end
+
 function module:CheckTarget()
 	local newtarget = nil
 	local enemy = "Eye of C'Thun"
@@ -718,15 +679,8 @@ function module:Phase2()
 	if self.db.profile.stomachhp then
 		firstStomachTentacleDead = nil
 		secondTentacleLowWarn = nil
-		firstTentacleHP = 100
-		secondTentacleHP = 100
 
-		self:TriggerEvent("BigWigs_StartHPBar", self, L["hpBar_firstTentacle"], 100, "Interface\\Icons\\" .. icon.stomachTentacle, true, color.stomachTentacle)
-		self:TriggerEvent("BigWigs_SetHPBar", self, L["hpBar_firstTentacle"], 0)
-		self:TriggerEvent("BigWigs_StartHPBar", self, L["hpBar_secondTentacle"], 100, "Interface\\Icons\\" .. icon.stomachTentacle, true, color.stomachTentacle)
-		self:TriggerEvent("BigWigs_SetHPBar", self, L["hpBar_secondTentacle"], 0)
-
-		self:ScheduleRepeatingEvent("CThunCheckTentacleHP", self.CheckTentacleHP, 0.5, self)
+		self:ScheduleEvent("CthunFindFleshTentacle", self.FindFleshTentacle, 12, self)
 	end
 
 	if self.db.profile.stomachplayers then
@@ -766,10 +720,8 @@ end
 function module:Weakened()
 	firstStomachTentacleDead = nil
 	secondTentacleLowWarn = nil
-	firstTentacleHP = 100
-	secondTentacleHP = 100
-	self:TriggerEvent("BigWigs_StopHPBar", self, L["hpBar_firstTentacle"])
-	self:TriggerEvent("BigWigs_StopHPBar", self, L["hpBar_secondTentacle"])
+	self:RemoveBar("stomachL")
+	self:RemoveBar("stomachR")
 
 	self:CancelDelayedMessage(L["msg_smallEyeTentaclesSoon"])
 	self:CancelDelayedSound("Alert")
@@ -777,6 +729,8 @@ function module:Weakened()
 
 	self:RemoveBar(L["bar_giantEye"])
 	self:RemoveBar(L["bar_giantClaw"])
+
+	self:CancelScheduledEvent("CthunCheckFleshTentacles")
 
 	if self.db.profile.weakened then
 		self:Message(L["msg_weakened"], "Positive", false, nil, false)
@@ -808,13 +762,8 @@ function module:WeakenedOver()
 	if self.db.profile.stomachhp then
 		firstStomachTentacleDead = nil
 		secondTentacleLowWarn = nil
-		firstTentacleHP = 100
-		secondTentacleHP = 100
 
-		self:TriggerEvent("BigWigs_StartHPBar", self, L["hpBar_firstTentacle"], 100, "Interface\\Icons\\" .. icon.stomachTentacle, true, color.stomachTentacle)
-		self:TriggerEvent("BigWigs_SetHPBar", self, L["hpBar_firstTentacle"], 0)
-		self:TriggerEvent("BigWigs_StartHPBar", self, L["hpBar_secondTentacle"], 100, "Interface\\Icons\\" .. icon.stomachTentacle, true, color.stomachTentacle)
-		self:TriggerEvent("BigWigs_SetHPBar", self, L["hpBar_secondTentacle"], 0)
+		self:ScheduleEvent("CthunFindFleshTentacle", self.FindFleshTentacle, 12, self)
 	end
 end
 
@@ -829,56 +778,54 @@ function module:FleshTentacleDead()
 		secondTentacleLowWarn = nil
 
 		self:Message(L["msg_firstTentacleDead"], "Important", false, nil, false)
-
-		firstTentacleHP = 1
-		secondTentacleHP = 100
-		self:TriggerEvent("BigWigs_SetHPBar", self, L["hpBar_firstTentacle"], 100 - firstTentacleHP)
-		self:TriggerEvent("BigWigs_SetHPBar", self, L["hpBar_secondTentacle"], 100 - secondTentacleHP)
 	end
 end
 
-function module:CheckTentacleHP()
-	local health
-	if UnitName("Target") == "Flesh Tentacle" and not UnitIsDeadOrGhost("Target") then
-		health = math.floor(UnitHealth("Target") / UnitHealthMax("Target") * 100)
+function module:FindFleshTentacle()
+	local found = BigWigs:GetGUIDByName(L["unit_fleshTentacle"], 1)
+	if found then
+		self:GetSecondFleshTentacle(found)
 	else
-		for i = 1, GetNumRaidMembers() do
-			if UnitName("Raid" .. i .. "Target") == "Flesh Tentacle" and not UnitIsDeadOrGhost("Raid" .. i .. "Target") then
-				health = math.floor(UnitHealth("Raid" .. i .. "Target") / UnitHealthMax("Raid" .. i .. "Target") * 100)
-				break
-			end
-		end
+		self:ScheduleEvent("CthunFindFleshTentacle", self.FindFleshTentacle, 0.5, self)
+	end
+end
+
+function module:GetSecondFleshTentacle(firstGUID)
+	local minus = BigWigs:OffsetGUID(firstGUID,-1)
+	local plus = BigWigs:OffsetGUID(firstGUID,1)
+	if minus and UnitExists(minus) and UnitName(minus) == L["unit_fleshTentacle"] then
+		guid.stomachL = firstGUID
+		guid.stomachR = minus
+	elseif plus and UnitExists(plus) and UnitName(plus) == L["unit_fleshTentacle"] then
+		guid.stomachL = plus
+		guid.stomachR = firstGUID
+	else
+		-- inferring the second tentacle from consecutive GUIDs is elegant, but possibly not 100% reliable?
+		print("Unable to find a second Flesh Tentacle - Please submit a bug report on Github!")
+		return
 	end
 
-	if secondTentacleLowWarn == true and health and health >= 20 then
-		secondTentacleLowWarn = nil
-		firstTentacleHP = 1
-		secondTentacleHP = 100
-		self:TriggerEvent("BigWigs_SetHPBar", self, L["hpBar_firstTentacle"], 100 - firstTentacleHP)
-		self:TriggerEvent("BigWigs_SetHPBar", self, L["hpBar_secondTentacle"], 100 - secondTentacleHP)
+	self:MonitorBar("stomachL", icon.stomachTentacle, guid.stomachL, "health", "Left")
+	self:MonitorBar("stomachR", icon.stomachTentacle, guid.stomachR, "health", "Right")
+	self:ScheduleRepeatingEvent("CthunCheckFleshTentacles", self.CheckFleshTentacles, 0.5, self)
+end
+
+function module:CheckFleshTentacles()
+	if secondTentacleLowWarn or not firstStomachTentacleDead then
+		return
 	end
 
-	if not firstStomachTentacleDead then
-		if health and health < firstTentacleHP then
-			firstTentacleHP = health
-			self:TriggerEvent("BigWigs_SetHPBar", self, L["hpBar_firstTentacle"], 100 - firstTentacleHP)
-			self:TriggerEvent("BigWigs_SetHPBar", self, L["hpBar_secondTentacle"], 100 - secondTentacleHP)
-		elseif health and health > firstTentacleHP and health < secondTentacleHP then
-			secondTentacleHP = health
-			self:TriggerEvent("BigWigs_SetHPBar", self, L["hpBar_firstTentacle"], 100 - firstTentacleHP)
-			self:TriggerEvent("BigWigs_SetHPBar", self, L["hpBar_secondTentacle"], 100 - secondTentacleHP)
-		end
-	elseif firstStomachTentacleDead then
-		firstTentacleHP = 1
-		if health and health < secondTentacleHP then
-			secondTentacleHP = health
-			self:TriggerEvent("BigWigs_SetHPBar", self, L["hpBar_firstTentacle"], 100 - firstTentacleHP)
-			self:TriggerEvent("BigWigs_SetHPBar", self, L["hpBar_secondTentacle"], 100 - secondTentacleHP)
-		end
-		if secondTentacleHP <= 20 and not secondTentacleLowWarn then
-			self:Message("Second Tentacle at " .. secondTentacleHP .. "% HP")
-			secondTentacleLowWarn = true
-		end
+	local guidSecond
+	if UnitExists(guid.stomachL) and not UnitIsDead(guid.stomachL) then
+		guidSecond = guid.stomachL
+	elseif UnitExists(guid.stomachR) and not UnitIsDead(guid.stomachR) then
+		guidSecond = guid.stomachR
+	end
+
+	local percent = UnitHealth(guidSecond) / UnitHealthMax(guidSecond) * 100
+	if percent <= 20 then
+		self:Message(string.format(L["msg_secondTentacleLow"],percent), "Urgent")
+		secondTentacleLowWarn = true
 	end
 end
 

--- a/Raids/DireMaul/EyeOfKilrogg.lua
+++ b/Raids/DireMaul/EyeOfKilrogg.lua
@@ -86,10 +86,7 @@ function module:BigWigs_RecvSync(sync, rest, nick)
 end
 
 function module:NetherPortal()
-	self:Bar(L["bar_netherPortal"], timer.netherPortal, icon.netherPortal)
-	self:SetCandyBarOnClick("BigWigsBar " .. L["bar_netherPortal"], function(name, button)
-			TargetByName(L["unit_EyeOfKilrogg"], true)
-		end)
+	self:ClickBar(L["bar_netherPortal"], timer.netherPortal, icon.netherPortal, L["unit_EyeOfKilrogg"])
 	self:WarningSign(icon.eye, timer.netherPortal)
 	self:Sound("Beware")
 end

--- a/Raids/KarazhanUpper/Anomalus.lua
+++ b/Raids/KarazhanUpper/Anomalus.lua
@@ -62,6 +62,8 @@ L:RegisterTranslations("enUS", function()
 		trigger_arcaneDampeningFade = "Arcane Dampening fades from (.+)",
 
 		bar_manaboundExpire = "Manabound stacks expire",
+
+		spellEffectWarning = "BigWigs: Your spellEffectLevel is set to 0, this makes void/pink zones impossible to see.  Consider changing this in your graphics options or typing /run SetCVar(\"spellEffectLevel\", 2).",
 	}
 end)
 
@@ -114,6 +116,12 @@ function module:OnEnable()
 	self:ThrottleSync(3, syncName.arcaneDampeningFade)
 
 	self:UpdateManaboundStatusFrame()
+
+	-- check if spellEffectLevel is set to 0 and warn
+	if GetCVar("spellEffectLevel") == "0" then
+		self:Message(L["spellEffectWarning"], "Attention")
+		DEFAULT_CHAT_FRAME:AddMessage(L["spellEffectWarning"], 1, 1, 0)
+	end
 end
 
 function module:OnSetup()

--- a/Raids/KarazhanUpper/ChessFight.lua
+++ b/Raids/KarazhanUpper/ChessFight.lua
@@ -158,8 +158,9 @@ L:RegisterTranslations("enUS", function()
 		bar_subservience = "Go right in front of Queen and Bow! >Click Me<",
 		bar_kingsfury = "King's Fury - Hide!",
 		bar_charmingpresence = "Next Charming Presence",
-		bar_decursebow = "Decurse %s >Click Me<",
-		bar_curseCD = "possible King's Curse",
+		bar_decursebow = (playerClass=="MAGE" and ">Decurse %s!< for /bow") or (playerClass=="DRUID" and ">Decurse %s!< for bow") or "Decurse %s for /bow",
+		spell_decursebow = (playerClass=="MAGE" and "Remove Lesser Curse") or (playerClass=="DRUID" and "Remove Curse") or false,
+		bar_curseCD = "King's Curse on CD",
 
 		bishop_name = "Bishop",
 		bishop_needsTongues = "Bishop needs Curse of Tongues!",
@@ -247,16 +248,13 @@ function module:OnEnable()
 	self:RegisterEvent("CHAT_MSG_SPELL_AURA_GONE_PARTY", "FadesEvent")
 	self:RegisterEvent("CHAT_MSG_SPELL_AURA_GONE_OTHER", "FadesEvent")
 
-	self:RegisterEvent("CHAT_MSG_MONSTER_EMOTE", "CastEvent")
-	self:RegisterEvent("CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE", "CastEvent")
-	self:RegisterEvent("CHAT_MSG_SPELL_CREATURE_VS_CREATURE_BUFF", "CastEvent")
+	self:RegisterEvent("CHAT_MSG_SPELL_CREATURE_VS_SELF_DAMAGE", "SpellEvent")
+	self:RegisterEvent("CHAT_MSG_SPELL_CREATURE_VS_PARTY_DAMAGE", "SpellEvent")
+	self:RegisterEvent("CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE", "SpellEvent")
+	self:RegisterEvent("CHAT_MSG_SPELL_CREATURE_VS_CREATURE_BUFF", "SpellEvent")
 
 	self:RegisterEvent("CHAT_MSG_SPELL_PERIODIC_CREATURE_BUFFS", "EnemyDebuffEvent")
 	self:RegisterEvent("CHAT_MSG_SPELL_PERIODIC_CREATURE_DAMAGE", "EnemyDebuffEvent")
-
-	self:RegisterEvent("CHAT_MSG_SPELL_CREATURE_VS_SELF_DAMAGE", "SpellHitEvent")
-	self:RegisterEvent("CHAT_MSG_SPELL_CREATURE_VS_PARTY_DAMAGE", "SpellHitEvent")
-	self:RegisterEvent("CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE", "SpellHitEvent")
 
 	if self.db.profile.bishoptonguesalert then
 		self:ScheduleRepeatingEvent("BishopDebuffScan", self.ScanBishopDebuffs, timer.bishopScan, self)
@@ -366,7 +364,7 @@ function module:RookCastEvent(casterGuid, targetGuid, eventType, spellId, castTi
 	end
 end
 
-function module:CastEvent(msg)
+function module:SpellEvent(msg)
 	if string.find(msg, L["trigger_subservienceFailed"]) and self.queenTarget ~= "" then
 		self:Sync(syncName.subservienceFailed .. " " .. self.queenTarget)
 	elseif string.find(msg, L["trigger_kingCastFury"]) then
@@ -378,6 +376,12 @@ function module:CastEvent(msg)
 		self:Sync(syncName.sbvolleyCast)
 	elseif self.db.profile.empoweredsb and string.find(msg, L["trigger_empoweredCast"]) then
 		self:Message(L["msg_empoweredCast"], "Urgent", nil, "Info")		
+	end
+	if self.db.profile.printchess then
+		local _,_,player,amount = string.find(msg, L["trigger_kingsFuryHit"])
+		if player and amount and tonumber(amount) > 8000 then
+			print(msg)
+		end
 	end
 end
 
@@ -516,15 +520,6 @@ function module:OnFriendlyDeath(msg)
 	end
 end
 
-function module:SpellHitEvent(msg)
-	if self.db.profile.printchess then
-		local _,_,player,amount = string.find(msg, L["trigger_kingsFuryHit"])
-		if player and amount and tonumber(amount) > 8000 then
-			print(msg)
-		end
-	end
-end
-
 function module:BigWigs_RecvSync(sync, rest, nick)
 	if sync == syncName.subservience and rest and rest ~= UnitName("player") then
 		self:Subservience(rest)
@@ -636,7 +631,7 @@ function module:Subservience(player)
 					if texture then
 						if texture == kingsCurseTexture then
 							-- Player has King's Curse, show decurse reminder
-							self:DecurseReminder(player, raidTarget)
+							self:DecurseReminder(player)
 							break
 						end
 					else
@@ -657,32 +652,12 @@ function module:Subservience(player)
 	end
 end
 
-function module:DecurseReminder(player, raidTarget)
+function module:DecurseReminder(player)
 	if not self.db.profile.decursebow then
 		return
 	end
 
-	-- Create a bar with decurse functionality
-	local barText = string.format(L["bar_decursebow"], player)
-	self:Bar(barText, timer.subservience, icon.kingscurse)
-
-	-- Set the bar to target player and cast Remove Curse when clicked
-	self:SetCandyBarOnClick("BigWigsBar " .. barText, function(name, button, playerName, target)
-		if SUPERWOW_VERSION or SetAutoloot then
-			if playerClass == "MAGE" then
-				CastSpellByName("Remove Lesser Curse", target)
-			elseif playerClass == "DRUID" then
-				CastSpellByName("Remove Curse", target)
-			end
-		else
-			TargetByName(playerName, true)
-			if playerClass == "MAGE" then
-				CastSpellByName("Remove Lesser Curse")
-			elseif playerClass == "DRUID" then
-				CastSpellByName("Remove Curse")
-			end
-		end
-	end, player, raidTarget)
+	self:ClickBar(string.format(L["bar_decursebow"], player), timer.subservience, icon.kingscurse, player, L["spell_decursebow"])
 end
 
 function module:KingCastFury()
@@ -848,7 +823,7 @@ function module:Test()
 		{ time = 12, func = function()
 			local msg = testPlayerName1 .. " is afflicted by Dark Subservience"
 			module:AfflictionEvent(msg)
-			module:DecurseReminder(testPlayerName1, "raid1")
+			module:DecurseReminder(testPlayerName1)
 			print("Test: " .. msg)
 		end },
 
@@ -868,7 +843,7 @@ function module:Test()
 		-- Test SBV from Bishop
 		{ time = 22, func = function()
 			local msg = "Bishop begins to cast Shadow Bolt Volley"
-			module:CastEvent(msg)
+			module:SpellEvent(msg)
 			print("Test: " .. msg)
 		end },
 
@@ -881,7 +856,7 @@ function module:Test()
 
 		{ time = 25, func = function()
 			local msg = "Dark Subservience fails. Grounding Totem"
-			module:CastEvent(msg)
+			module:SpellEvent(msg)
 			print("Test: " .. msg)
 		end },
 
@@ -895,7 +870,7 @@ function module:Test()
 		-- King's Fury event
 		{ time = 28, func = function()
 			local msg = "King begins to cast King’s Fury"
-			module:CastEvent(msg)
+			module:SpellEvent(msg)
 			print("Test: " .. msg)
 		end },
 
@@ -903,7 +878,7 @@ function module:Test()
 		{ time = 30, func = function()
 			local msg = testPlayerName2 .. " is afflicted by Dark Subservience"
 			module:AfflictionEvent(msg)
-			module:DecurseReminder(testPlayerName2, "raid2")
+			module:DecurseReminder(testPlayerName2)
 			print("Test: " .. msg)
 		end },
 
@@ -957,7 +932,7 @@ function module:Test()
 		-- King's Fury event
 		{ time = 36, func = function()
 			local msg = "King begins to cast King’s Fury"
-			module:CastEvent(msg)
+			module:SpellEvent(msg)
 			print("Test: " .. msg)
 		end },
 
@@ -970,20 +945,20 @@ function module:Test()
 		-- Test SBV from Bishop with full length
 		{ time = 38, func = function()
 			local msg = "Bishop begins to cast Shadow Bolt Volley"
-			module:CastEvent(msg)
+			module:SpellEvent(msg)
 			print("Test: " .. msg)
 		end },
 
 		-- King's Fury hit
 		{ time = 38, func = function()
 			local msg = "King's King’s Fury hits Bob for 18000 Holy damage."
-			module:SpellHitEvent(msg)
+			module:SpellEvent(msg)
 			print("Test: " .. msg)
 		end },
 
 		{ time = 39, func = function()
 			local msg = "King's King’s Fury hits BobsPet for 3600 Holy damage."
-			module:SpellHitEvent(msg)
+			module:SpellEvent(msg)
 			print("Test: " .. msg)
 		end },
 

--- a/Raids/KarazhanUpper/EchoOfMedivh.lua
+++ b/Raids/KarazhanUpper/EchoOfMedivh.lua
@@ -391,12 +391,7 @@ function module:CorruptionOfMedivh(player)
 	
 	-- Display bar with on-click target if enabled
 	if self.db.profile.corruptiontarget and player ~= UnitName("player") then
-		local barText = string.format(L["bar_corruption"], player)
-		self:Bar(barText, timer.corruption, icon.corruption, true, "Black")
-		
-		self:SetCandyBarOnClick("BigWigsBar " .. barText, function(name, button, playerName)
-			TargetByName(playerName, true)
-		end, player)
+		self:ClickBar(string.format(L["bar_corruption"], player), timer.corruption, icon.corruption, player, false, true, "Black")
 	end
 end
 

--- a/Raids/KarazhanUpper/Incantagos.lua
+++ b/Raids/KarazhanUpper/Incantagos.lua
@@ -3,7 +3,7 @@ local module, L = BigWigs:ModuleDeclaration("Ley-Watcher Incantagos", "Karazhan"
 -- module variables
 module.revision = 30003
 module.enabletrigger = module.translatedName
-module.toggleoptions = { "leyline", "affinity", "targetBlack", "targetBlue", "targetCrystal", "targetGreen", "targetMana", "targetRed", -1, "surgewarning", "surgesay", "summonseeker", "summonwhelps", -1, "beam", "blizzard", "proximity", "cursewarning", "bosskill"}
+module.toggleoptions = { "leyline", "affinity", "targetBlack", "targetBlue", "targetCrystal", "targetGreen", "targetMana", "targetRed", -1, "surgewarning", "surgesay", "summonseeker", "summonwhelps", "summoncd", -1, "beam", "blizzard", "proximity", "cursewarning", "bosskill"}
 module.zonename = {
 	AceLibrary("AceLocale-2.2"):new("BigWigs")["Tower of Karazhan"],
 	AceLibrary("Babble-Zone-2.2")["Tower of Karazhan"],
@@ -25,6 +25,7 @@ module.defaultDB = {
 	surgesay = true,
 	summonseeker = true,
 	summonwhelps = true,
+	summoncd = false,
 	beam = true,
 	blizzard = true,
 	proximity = false,
@@ -84,6 +85,10 @@ L:RegisterTranslations("enUS", function()
 		summonwhelps_name = "Summon Whelps Alert",
 		summonwhelps_desc = "Warns when Ley-Watcher Incantagos summons Manascale Whelps",
 
+		summoncd_cmd = "summoncd",
+		summoncd_name = "Summon Cooldown Timer",
+		summoncd_desc = "Shows a timer bar for the minimum cooldown of the next possible wave of summons",
+
 		beam_cmd = "beam",
 		beam_name = "Guided Ley-Beam Alert",
 		beam_desc = "Warns when players are affected by Guided Ley-Beam",
@@ -115,12 +120,12 @@ L:RegisterTranslations("enUS", function()
 		trigger_manaAffinity = "gains Mana Affinity",
 		trigger_redAffinity = "gains Red Affinity",
 
-		mob_blackAffinity = "Black Affinity",
-		mob_blueAffinity = "Blue Affinity",
-		mob_crystalAffinity = "Crystal Affinity",
-		mob_greenAffinity = "Green Affinity",
-		mob_manaAffinity = "Mana Affinity",
-		mob_redAffinity = "Red Affinity",
+		unit_blackAffinity = "Black Affinity",
+		unit_blueAffinity = "Blue Affinity",
+		unit_crystalAffinity = "Crystal Affinity",
+		unit_greenAffinity = "Green Affinity",
+		unit_manaAffinity = "Mana Affinity",
+		unit_redAffinity = "Red Affinity",
 
 		msg_blackAffinity = "BLACK AFFINITY - Priests and Warlocks handle this!",
 		msg_blueAffinity = "BLUE AFFINITY - Mages handle this!",
@@ -129,12 +134,12 @@ L:RegisterTranslations("enUS", function()
 		msg_manaAffinity = "MANA AFFINITY - Mages and Druids handle this!",
 		msg_redAffinity = "RED AFFINITY - Mages and Warlocks handle this!",
 
-		bar_blackAffinity = "Black Affinity (Shadow)",
-		bar_blueAffinity = "Blue Affinity (Frost)",
-		bar_crystalAffinity = "Crystal Affinity (Physical)",
-		bar_greenAffinity = "Green Affinity (Nature)",
-		bar_manaAffinity = "Mana Affinity (Arcane)",
-		bar_redAffinity = "Red Affinity (Fire)",
+		bar_blackAffinity = "Shadow Affinity >target<",
+		bar_blueAffinity = "Frost Affinity >target<",
+		bar_crystalAffinity = "Physical Affinity >target<",
+		bar_greenAffinity = "Nature Affinity >target<",
+		bar_manaAffinity = "Arcane Affinity >target<",
+		bar_redAffinity = "Fire Affinity >target<",
 
 		warn_blackAffinity = "SHADOW",
 		warn_blueAffinity = "FROST",
@@ -149,17 +154,18 @@ L:RegisterTranslations("enUS", function()
 		trigger_surgeDeath = "(.+) die",
 		msg_surgeYou = "Surge of Mana on YOU!",
 		msg_surge = "Surge on %s",
-		bar_surge = "Surge on %s >Click Me!<",
+		bar_surge = (playerClass=="PALADIN" and "Surge on %s >freedom<") or "Surge on %s >target<",
+		spell_surge = (playerClass=="PALADIN" and "Hand of Freedom") or false,
 		warn_surge = "SURGE OF MANA",
 		yell_surge = "Help me! (Surge of Mana)",
 
 		trigger_summonSeekerCast = "Watcher Incantagos begins to cast Summon Manascale Ley",
-		bar_summonSeekerCast = "Ley-Seeker Summoning",
 		msg_summonSeeker = "Manascale Ley-Seeker spawning in 2 sec!",
 
 		trigger_summonWhelpsCast = "Watcher Incantagos begins to cast Summon Manascale Whelps",
-		bar_summonWhelpsCast = "Whelps Summoning",
 		msg_summonWhelps = "Manascale Whelps spawning in 2 sec!",
+		
+		bar_summonCD = "Next Summon Wave",
 
 		trigger_leyBeamGain = "(.+) gain.? Guided Ley",
 		trigger_leyBeamAfflicted = "afflicted by Guided Ley",
@@ -193,6 +199,7 @@ local timer = {
 	leyLineCast = 3,
 	summonSeekerCast = 2,
 	summonWhelpsCast = 2,
+	summonCD = { 30, 40 },
 	affinity = 15,
 	initalBeamCD = 28,
 	beam = 13, -- 10 sec duration, starts 3 sec after initial targeting buff
@@ -201,6 +208,7 @@ local timer = {
 
 local icon = {
 	leyLine = "Spell_Arcane_PortalIronForge",
+	summonCD = "INV_Misc_Head_Dragon_Blue",
 	greenAffinity = "Spell_Nature_AbolishMagic",
 	blackAffinity = "Spell_Shadow_ShadowBolt",
 	redAffinity = "Spell_Fire_FlameBolt",
@@ -215,8 +223,6 @@ local icon = {
 
 local color = {
 	leyLine = "Blue",
-	summonSeeker = "Yellow",
-	summonWhelps = "Orange",
 }
 
 local syncName = {
@@ -231,6 +237,10 @@ local syncName = {
 	crystalAffinity = "IncantagosCrystalAffinity" .. module.revision,
 	beam = "IncantagosLeyBeam" .. module.revision,
 	allSeekersDead = "IncantagosSeekersDead" .. module.revision,
+}
+
+local guid = {
+	incantagos = "0xF13000F1FA276A32"
 }
 
 -- Proximity Plugin
@@ -278,8 +288,8 @@ function module:OnSetup()
 	self.started = nil
 	self.curseWarned = nil
 	self.hitEightyFive = nil
-	self.bossHealth = 100
 	self.seekersLeft = 4
+	self.lastSeekerSummon = 0
 end
 
 function module:OnEngage()
@@ -293,11 +303,10 @@ function module:OnEngage()
 
 	self.curseWarned = nil
 	self.hitEightyFive = nil
-	self.bossHealth = 100
 	self.seekersLeft = 4
 
 	-- Start health monitoring
-	self:ScheduleRepeatingEvent("CheckBossHealth", self.CheckBossHealth, 1, self)
+	self:ScheduleRepeatingEvent("CheckBossHealth", self.CheckBossHealth, 0.5, self)
 end
 
 function module:OnDisengage()
@@ -306,6 +315,7 @@ function module:OnDisengage()
 	if self:IsEventScheduled("CheckBossHealth") then
 		self:CancelScheduledEvent("CheckBossHealth")
 	end
+	self:CancelDelayedBar(L["bar_summonCD"])
 end
 
 function module:IncantagosCastEvent(casterGuid, targetGuid, eventType, spellId, castTime)
@@ -317,31 +327,21 @@ function module:IncantagosCastEvent(casterGuid, targetGuid, eventType, spellId, 
 end
 
 function module:CheckBossHealth()
-	for i = 1, GetNumRaidMembers() do
-		local targetString = "raid" .. i .. "target"
-		local targetName = UnitName(targetString)
+	if UnitExists(guid.incantagos) then
+		local percent = UnitHealth(guid.incantagos)/UnitHealthMax(guid.incantagos) * 100
 
-		if targetName == module.translatedName then
-			local health = UnitHealth(targetString)
-			local healthMax = UnitHealthMax(targetString)
-
-			if health > 0 and healthMax > 0 then
-				self.bossHealth = math.ceil((health / healthMax) * 100)
-
-				if self.bossHealth <= 85 and not self.hitEightyFive then
-					if self.seekersLeft > 0 then
-						self:Message(L["msg_seekerWarn"], "Important", nil, "Beware")
-					end
-					self.hitEightyFive = true
-				end
-				if self.bossHealth <= 38 and not self.curseWarned then
-					if self.db.profile.cursewarning then
-						self:Message(L["msg_curseWarning"], "Important", nil, "Alarm")
-					end
-					self.curseWarned = true
-				end
-				break
+		if percent <= 85 and not self.hitEightyFive then
+			if self.seekersLeft > 0 then
+				self:Message(L["msg_seekerWarn"], "Important", nil, "Beware")
 			end
+			self.hitEightyFive = true
+		end
+		if percent <= 38 and not self.curseWarned then
+			if self.db.profile.cursewarning then
+				self:Message(L["msg_curseWarning"], "Important", nil, "Alarm")
+			end
+			self.curseWarned = true
+			self:CancelScheduledEvent("CheckBossHealth")
 		end
 	end
 end
@@ -469,6 +469,9 @@ function module:BigWigs_RecvSync(sync, rest, nick)
 end
 
 function module:SummonSeeker()
+	self:CancelDelayedBar(L["bar_summonCD"])
+	self:RemoveBar(L["bar_summonCD"])
+	self.lastSeekerSummon = GetTime()
 	if self.db.profile.summonseeker then
 		self:Message(L["msg_summonSeeker"], "Attention")
 	end
@@ -477,6 +480,12 @@ end
 function module:SummonWhelps()
 	if self.db.profile.summonwhelps then
 		self:Message(L["msg_summonWhelps"], "Attention")
+	end
+	if self.db.profile.summoncd then
+		local delay = 5
+		local nextSeekerMin = timer.summonCD[1] + self.lastSeekerSummon - GetTime() - delay
+		local nextSeekerMax = timer.summonCD[2] + self.lastSeekerSummon - GetTime() - delay
+		self:DelayedIntervalBar(delay, L["bar_summonCD"], nextSeekerMin, nextSeekerMax, icon.summonCD, true, "White")
 	end
 end
 
@@ -494,10 +503,10 @@ function module:BlackAffinity()
 	if self.db.profile.affinity then
 		self:Message(L["msg_blackAffinity"], "Important", true, "Alarm")
 		self:WarningSign(icon.blackAffinity, 5, true, L["warn_blackAffinity"])
-		self:Bar(L["bar_blackAffinity"], timer.affinity, icon.blackAffinity)
+		self:ClickBar(L["bar_blackAffinity"], timer.affinity, icon.blackAffinity, L["unit_blackAffinity"])
 	end
 	if self.db.profile.targetBlack then
-		TargetByName(L["mob_blackAffinity"],true)
+		TargetByName(L["unit_blackAffinity"],true)
 	end
 end
 
@@ -505,10 +514,10 @@ function module:BlueAffinity()
 	if self.db.profile.affinity then
 		self:Message(L["msg_blueAffinity"], "Important", true, "Alarm")
 		self:WarningSign(icon.blueAffinity, 5, true, L["warn_blueAffinity"])
-		self:Bar(L["bar_blueAffinity"], timer.affinity, icon.blueAffinity)
+		self:ClickBar(L["bar_blueAffinity"], timer.affinity, icon.blueAffinity, L["unit_blueAffinity"])
 	end
 	if self.db.profile.targetBlue then
-		TargetByName(L["mob_blueAffinity"],true)
+		TargetByName(L["unit_blueAffinity"],true)
 	end
 end
 
@@ -516,10 +525,10 @@ function module:CrystalAffinity()
 	if self.db.profile.affinity then
 		self:Message(L["msg_crystalAffinity"], "Important", true, "Alarm")
 		self:WarningSign(icon.crystalAffinity, 5, true, L["warn_crystalAffinity"])
-		self:Bar(L["bar_crystalAffinity"], timer.affinity, icon.crystalAffinity)
+		self:ClickBar(L["bar_crystalAffinity"], timer.affinity, icon.crystalAffinity, L["unit_crystalAffinity"])
 	end
 	if self.db.profile.targetCrystal then
-		TargetByName(L["mob_crystalAffinity"],true)
+		TargetByName(L["unit_crystalAffinity"],true)
 	end
 end
 
@@ -527,10 +536,10 @@ function module:GreenAffinity()
 	if self.db.profile.affinity then
 		self:Message(L["msg_greenAffinity"], "Important", true, "Alarm")
 		self:WarningSign(icon.greenAffinity, 5, true, L["warn_greenAffinity"])
-		self:Bar(L["bar_greenAffinity"], timer.affinity, icon.greenAffinity)
+		self:ClickBar(L["bar_greenAffinity"], timer.affinity, icon.greenAffinity, L["unit_greenAffinity"])
 	end
 	if self.db.profile.targetGreen then
-		TargetByName(L["mob_greenAffinity"],true)
+		TargetByName(L["unit_greenAffinity"],true)
 	end
 end
 
@@ -538,10 +547,10 @@ function module:ManaAffinity()
 	if self.db.profile.affinity then
 		self:Message(L["msg_manaAffinity"], "Important", true, "Alarm")
 		self:WarningSign(icon.manaAffinity, 5, true, L["warn_manaAffinity"])
-		self:Bar(L["bar_manaAffinity"], timer.affinity, icon.manaAffinity)
+		self:ClickBar(L["bar_manaAffinity"], timer.affinity, icon.manaAffinity, L["unit_manaAffinity"])
 	end
 	if self.db.profile.targetMana then
-		TargetByName(L["mob_manaAffinity"],true)
+		TargetByName(L["unit_manaAffinity"],true)
 	end
 end
 
@@ -549,10 +558,10 @@ function module:RedAffinity()
 	if self.db.profile.affinity then
 		self:Message(L["msg_redAffinity"], "Important", true, "Alarm")
 		self:WarningSign(icon.redAffinity, 5, true, L["warn_redAffinity"])
-		self:Bar(L["bar_redAffinity"], timer.affinity, icon.redAffinity)
+		self:ClickBar(L["bar_redAffinity"], timer.affinity, icon.redAffinity, L["unit_redAffinity"])
 	end
 	if self.db.profile.targetRed then
-		TargetByName(L["mob_redAffinity"],true)
+		TargetByName(L["unit_redAffinity"],true)
 	end
 end
 
@@ -582,6 +591,8 @@ end
 
 function module:SurgeBar(player)
 	if self.db.profile.surgewarning then
+		self:ClickBar(string.format(L["bar_surge"], player), timer.surge, icon.surge, player, L["spell_surge"], true, "Cyan")
+		
 		local barText = string.format(L["bar_surge"], player)
 		self:Bar(barText, timer.surge, icon.surge, true, "Cyan")
 		
@@ -613,6 +624,9 @@ function module:Test()
 	self:OnSetup()
 	self:Engage()
 
+	local player1 = UnitName("raid1") or "Player1"
+	local player2 = UnitName("raid2") or "Player2"
+
 	local events = {
 		-- First Ley-Line around 1:15
 		{ time = 4, func = function()
@@ -631,11 +645,6 @@ function module:Test()
 			end
 		end },
 
-		-- Summon Seeker
-		{ time = 7, func = function()
-			print("Test: Ley-Watcher Incantagos begins to cast Summon Manascale Ley-Seeker")
-			module:BeginsCastEvent("Ley-Watcher Incantagos begins to cast Summon Manascale Ley-Seeker.")
-		end },
 		-- Kill one initial Seeker
 		{ time = 8, func = function()
 			local msg = "Manascale Ley-Seeker dies."
@@ -669,6 +678,11 @@ function module:Test()
 			module:CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_BUFFS("You gain Guided Ley-Beam (1).")
 		end },
 
+		-- Summon Seeker
+		{ time = 23, func = function()
+			print("Test: Ley-Watcher Incantagos begins to cast Summon Manascale Ley-Seeker")
+			module:BeginsCastEvent("Ley-Watcher Incantagos begins to cast Summon Manascale Ley-Seeker.")
+		end },
 		-- Summon Whelps
 		{ time = 25, func = function()
 			print("Test: Ley-Watcher Incantagos begins to cast Summon Manascale Whelps")
@@ -707,6 +721,17 @@ function module:Test()
 			module:BuffEvent("Player1 gains Crystal Affinity (1).")
 		end },
 
+		-- Summon Seeker 2
+		{ time = 58, func = function()
+			print("Test: Ley-Watcher Incantagos begins to cast Summon Manascale Ley-Seeker")
+			module:BeginsCastEvent("Ley-Watcher Incantagos begins to cast Summon Manascale Ley-Seeker.")
+		end },
+		-- Summon Whelps 2
+		{ time = 61, func = function()
+			print("Test: Ley-Watcher Incantagos begins to cast Summon Manascale Whelps")
+			module:BeginsCastEvent("Ley-Watcher Incantagos begins to cast Summon Manascale Whelps.")
+		end },
+
 		-- Second Ley-Line about 55s after first one
 		{ time = 65, func = function()
 			print("Test: Ley-Watcher Incantagos begins to cast Ley-Line Disturbance")
@@ -720,12 +745,12 @@ function module:Test()
 			self:TriggerEvent("CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE", msg)
 		end },
 		{ time = 68.5, func = function()
-			local msg = UnitName("raid1").." is afflicted by Surge of Mana."
+			local msg = player1.." is afflicted by Surge of Mana."
 			print("Test: " .. msg)
 			self:TriggerEvent("CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE", msg)
 		end },
 		{ time = 68.7, func = function()
-			local msg = UnitName("raid2").." is afflicted by Surge of Mana."
+			local msg = player2.." is afflicted by Surge of Mana."
 			print("Test: " .. msg)
 			self:TriggerEvent("CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE", msg)
 		end },
@@ -735,12 +760,12 @@ function module:Test()
 			self:TriggerEvent("CHAT_MSG_SPELL_AURA_GONE_SELF", msg)
 		end },
 		{ time = 72, func = function()
-			local msg = "Surge of Mana fades from "..UnitName("raid1").."."
+			local msg = "Surge of Mana fades from "..player1.."."
 			print("Test: " .. msg)
 			self:TriggerEvent("CHAT_MSG_SPELL_AURA_GONE_PARTY", msg)
 		end },
 		{ time = 73, func = function()
-			local msg = "Surge of Mana fades from "..UnitName("raid2").."."
+			local msg = "Surge of Mana fades from "..player2.."."
 			print("Test: " .. msg)
 			self:TriggerEvent("CHAT_MSG_SPELL_AURA_GONE_OTHER", msg)
 		end },
@@ -750,12 +775,12 @@ function module:Test()
 			self:TriggerEvent("CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE", msg)
 		end },
 		{ time = 77, func = function()
-			local msg = UnitName("raid1").." is afflicted by Surge of Mana."
+			local msg = player1.." is afflicted by Surge of Mana."
 			print("Test: " .. msg)
 			self:TriggerEvent("CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE", msg)
 		end },
 		{ time = 79, func = function()
-			local msg = UnitName("raid1").." dies."
+			local msg = player2.." dies."
 			print("Test: " .. msg)
 			self:TriggerEvent("CHAT_MSG_COMBAT_FRIENDLY_DEATH", msg)
 		end },

--- a/Raids/KarazhanUpper/Mephistroth.lua
+++ b/Raids/KarazhanUpper/Mephistroth.lua
@@ -2,7 +2,7 @@ local module, L = BigWigs:ModuleDeclaration("Mephistroth", "Karazhan")
 
 module.revision = 30003
 module.enabletrigger = module.translatedName
-module.toggleoptions = { "shacklescast", "shacklesdebuff", "shackleshatter", -1, "shardscd", "shardschannel", "shardscount", -1, "doomduration", "markdoom", -1, "nightmare", "marknightmare", -1, "vampaura", "vampcorruption", -1, "fearcast", "bosskill" }
+module.toggleoptions = { "shacklescast", "shacklesdebuff", "shacklescd", "shackleshatter", -1, "shardscd", "shardschannel", "shardscount", -1, "doomduration", "markdoom", -1, "nightmare", "marknightmare", -1, "vampaura", "vampcorruption", -1, "fearcast", "fearcd", "bosskill" }
 module.zonename = {
 	AceLibrary("AceLocale-2.2"):new("BigWigs")["Tower of Karazhan"],
 	AceLibrary("Babble-Zone-2.2")["Tower of Karazhan"],
@@ -16,6 +16,7 @@ local _, playerClass = UnitClass("player")
 module.defaultDB = {
 	shacklescast = true,
 	shacklesdebuff = true,
+	shacklescd = true,
 	shackleshatter = false,
 	shardscd = true,
 	shardschannel = true,
@@ -27,6 +28,7 @@ module.defaultDB = {
 	vampaura = playerClass == "SHAMAN" or playerClass == "PRIEST",
 	vampcorruption = false,
 	fearcast = playerClass == "SHAMAN",
+	fearcd = false,
 }
 
 L:RegisterTranslations("enUS", function()
@@ -40,7 +42,11 @@ L:RegisterTranslations("enUS", function()
 
 		shacklesdebuff_cmd = "shacklesdebuff",
 		shacklesdebuff_name = "Shackles Debuff Alert",
-		shacklesdebuff_desc = "Warn and timer when Shackles of the Legion lands.",
+		shacklesdebuff_desc = "Warning and duration timer when Shackles of the Legion lands",
+
+		shacklescd_cmd = "shacklescd",
+		shacklescd_name = "Shackles CD Timer",
+		shacklescd_desc = "Show timer for the minimum Shackles CD",
 
 		shackleshatter_cmd = "shackleshatter",
 		shackleshatter_name = "Shackle Shatter Tattle",
@@ -86,6 +92,10 @@ L:RegisterTranslations("enUS", function()
 		fearcast_name = "Nathrezim Terror cast",
 		fearcast_desc = "Shows an alert and a cast bar for incoming Nathrezim Terror (fear).",
 
+		fearcd_cmd = "fearcd",
+		fearcd_name = "Nathrezim Terror CD Timer",
+		fearcd_desc = "Shows a fading CD bar after each Nathrezim Terror cast.",
+
 		-- triggers
 		trigger_engage = "I foresaw your arrival", -- CHAT_MSG_MONSTER_YELL
 
@@ -122,6 +132,8 @@ L:RegisterTranslations("enUS", function()
 		msg_shacklesDebuffYou = "You are shackled! >>DO NOT MOVE<<",
 		msg_shacklesDebuffOther = "%s is shackled!",
 
+		bar_shacklesCD = "Shackles on CD",
+
 		msg_shackleShatter = " didn't keep still.",
 
 		bar_shardsChannel = "Shard Enrage",
@@ -133,7 +145,8 @@ L:RegisterTranslations("enUS", function()
 		msg_shardsOver = "Shards Phase Over",
 		msg_shardsFail = "Shards Phase Failed - Unfathomed Hatred triggered",
 
-		bar_doom = "Doom on %s >Decurse<",
+		bar_doom = (playerClass=="MAGE" and "Doom on %s >decurse<") or (playerClass=="DRUID" and "Doom on %s >decurse<") or "Doom on %s",
+		spell_doom = (playerClass=="MAGE" and "Remove Lesser Curse") or (playerClass=="DRUID" and "Remove Curse") or false,
 
 		msg_nightmare = "Crawler spawning on %s",
 
@@ -142,12 +155,13 @@ L:RegisterTranslations("enUS", function()
 
 		msg_fearCast = "Fear incoming!",
 		bar_fearCast = "Fear casting!",
+		bar_fearCD = "Fear on CD",
 	}
 end)
 
 local timer = {
 	shacklesInitialCD = { 68, 96 }, -- 60 to 120 ?
-	shacklesCD = { 40, 70 },
+	shacklesCD = { 40, 60 }, -- from logs: 40s to 60s cast-to-cast
 	shacklesCast = 2.5,
 	shacklesDebuff = 6,
 	shardsCast = 6,
@@ -159,6 +173,8 @@ local timer = {
 	vampiricAura = 15,
 	vampiricCorruption = 15,
 	fearCast = 2.5,
+	fearDuration = 5,
+	fearCD = { 26, 52 }, -- DCV-2142: 25 to 47; Elesion 29 to 56
 }
 
 local icon = {
@@ -452,10 +468,7 @@ function module:BigWigs_RecvSync(sync, rest, nick)
 		end
 
 	elseif sync == syncName.fearCast then
-		if self.db.profile.fearcast then
-			self:Message(L.msg_fearCast, "Core")
-			self:Bar(L.bar_fearCast, timer.fearCast, icon.fear, true, "Cyan")
-		end
+		self:NathrezimTerror()
 	end
 end
 
@@ -463,12 +476,19 @@ end
 --  Alerts & Bars
 --------------------------------------------------------------------------------
 function module:ShacklesCast(castTime)
-	if not self.db.profile.shacklescast then
-		return
+	-- remove any current or future CD bars
+	self:CancelDelayedBar(L.bar_shacklesCD)
+	self:RemoveBar(L.bar_shacklesCD)
+	
+	if self.db.profile.shacklescast then
+		self:Sound("Beware")
+		self:WarningSign(icon.shackles, castTime, true, L.msg_shacklesCastAlert)
+		self:Bar(L.bar_shacklesCast, castTime, icon.shackles, true, "Red")
 	end
-	self:Sound("Beware")
-	self:WarningSign(icon.shackles, castTime, true, L.msg_shacklesCastAlert)
-	self:Bar(L.bar_shacklesCast, castTime, icon.shackles, true, "Red")
+	if self.db.profile.shacklescd then
+		local delay = timer.shacklesCast + timer.shacklesDebuff + 1
+		self:DelayedIntervalBar(delay, L.bar_shacklesCD, timer.shacklesCD[1]-delay, timer.shacklesCD[2]-delay, icon.shackles, true, "Black")
+	end
 end
 
 function module:ShacklesDebuff(player)
@@ -523,37 +543,9 @@ function module:DoomGain(player)
 	if self.db.profile.markdoom then
 		self:SetRaidTargetForPlayer(player, 4) -- green triangle
 	end
-	
+
 	if self.db.profile.doomduration then
-		local barText = string.format(L.bar_doom, player)
-		self:Bar(barText, timer.doom, icon.doom, true, "Purple")
-		
-		-- Set the bar to target player and cast Remove Curse when clicked
-		local raidIndex = nil
-		for i = 1,40 do
-			local unit = "raid"..i
-			if UnitExists(unit) and UnitName(unit) == player then
-				raidIndex = unit
-				break
-			end
-		end
-		
-		self:SetCandyBarOnClick("BigWigsBar " .. barText, function(name, button, playerName, target)
-			if SUPERWOW_VERSION or SetAutoloot then
-				if playerClass == "MAGE" then
-					CastSpellByName("Remove Lesser Curse", target)
-				elseif playerClass == "DRUID" then
-					CastSpellByName("Remove Curse", target)
-				end
-			else
-				TargetByName(playerName, true)
-				if playerClass == "MAGE" then
-					CastSpellByName("Remove Lesser Curse")
-				elseif playerClass == "DRUID" then
-					CastSpellByName("Remove Curse")
-				end
-			end
-		end, player, raidIndex)
+		self:ClickBar(string.format(L.bar_doom, player), timer.doom, icon.doom, player, L.spell_doom, true, "Purple")
 	end
 end
 
@@ -578,6 +570,21 @@ end
 function module:NightmareFade(player)
 	if self.db.profile.marknightmare then
 		self:RestorePreviousRaidTargetForPlayer(player)
+	end
+end
+
+function module:NathrezimTerror()
+	-- remove any current or future CD bars
+	self:CancelDelayedBar(L.bar_fearCD)
+	self:RemoveBar(L.bar_fearCD)
+
+	if self.db.profile.fearcast then
+		self:Message(L.msg_fearCast, "Core")
+		self:Bar(L.bar_fearCast, timer.fearCast, icon.fear, true, "Cyan")
+	end
+	if self.db.profile.fearcd then
+		local delay = timer.fearCast + timer.fearDuration + 1
+		self:DelayedIntervalBar(delay, L.bar_fearCD, timer.fearCD[1]-delay, timer.fearCD[2]-delay, icon.fear, true, "ItemQuality0")
 	end
 end
 
@@ -642,6 +649,13 @@ function module:Test()
 		self:TriggerEvent("CHAT_MSG_SPELL_FRIENDLYPLAYER_DAMAGE", msg)	
 	end, 3 + 32)
 
+	-- first Fear
+	self:ScheduleEvent(self:ToString() .. "FearTest1", function()
+		local msg = "Mephistroth begins to cast Nathrezim Terror."
+		print("Test: " .. msg)
+		self:TriggerEvent("CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE",msg)
+	end, 3 + 35)
+
 	-- Shard Spawn
 	self:ScheduleEvent(self:ToString() .. "ShardsCDTest1", function()
 		BigWigs:TriggerEvent("UNIT_CASTEVENT", "player", "player", "START", spellIds.shardsCast, 6000)
@@ -655,6 +669,13 @@ function module:Test()
 		print("Test: " .. msg)
 		self:TriggerEvent("CHAT_MSG_MONSTER_YELL", msg)	
 	end, 3 + 42)
+
+	-- second Shackles
+	self:ScheduleEvent(self:ToString() .. "ShacklesDebuffTest7", function()
+		local msg = "Mephistroth begins to cast Shackles of the Legion!"
+		print("Test: " .. msg)
+		self:TriggerEvent("CHAT_MSG_RAID_BOSS_EMOTE", msg)
+	end, 0.5 + 47)
 
 	-- simulate hellfire shards ending their channel, naturally or by dying
 	self:ScheduleEvent(self:ToString() .. "ShardsChannelTest1_1", function()
@@ -732,11 +753,12 @@ function module:Test()
 		self:TriggerEvent("CHAT_MSG_SPELL_PERIODIC_CREATURE_BUFFS",msg)
 	end, 3 + 67)
 
-	self:ScheduleEvent(self:ToString() .. "FearTest", function()
+	-- second Fear
+	self:ScheduleEvent(self:ToString() .. "FearTest2", function()
 		local msg = "Mephistroth begins to cast Nathrezim Terror."
 		print("Test: " .. msg)
 		self:TriggerEvent("CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE",msg)
-	end, 3 + 70)
+	end, 3 + 35 + 35)
 
 	self:ScheduleEvent(self:ToString() .. "ShardFailTest", function()
 		local msg = "Mephistroth gains Unfathomed Hatred."
@@ -765,6 +787,13 @@ function module:Test()
 		print("Test: " .. msg)
 		self:TriggerEvent("CHAT_MSG_SPELL_AURA_GONE_SELF", msg)
 	end, 3 + 83)
+
+	-- third Shackles
+	self:ScheduleEvent(self:ToString() .. "ShacklesDebuffTest8", function()
+		local msg = "Mephistroth begins to cast Shackles of the Legion!"
+		print("Test: " .. msg)
+		self:TriggerEvent("CHAT_MSG_RAID_BOSS_EMOTE", msg)
+	end, 0.5 + 47 + 55)
 
 	-- Shard Spawn
 	self:ScheduleEvent(self:ToString() .. "ShardsCDTest2", function()

--- a/Raids/KarazhanUpper/Rupturan.lua
+++ b/Raids/KarazhanUpper/Rupturan.lua
@@ -2,7 +2,7 @@ local module, L = BigWigs:ModuleDeclaration("Rupturan the Broken", "Karazhan")
 
 module.revision = 30004
 module.enabletrigger = module.translatedName
-module.toggleoptions = { "livingstone", "dirtmound", "dirtmoundmark", "flamestrike", "flamestrikemove", "reform", "bosskill" }
+module.toggleoptions = { "boulderalert", "bouldermark", "bouldersay", "livingstone", "opportunity", -1, "igniteearth", "dirtmound", "dirtmoundmark", -1, "flamestrike", "flamestrikemove", "felheartalert", "felheartbar", "reform", "bosskill" }
 module.zonename = {
 	AceLibrary("AceLocale-2.2"):new("BigWigs")["Tower of Karazhan"],
 	AceLibrary("Babble-Zone-2.2")["Tower of Karazhan"],
@@ -10,13 +10,22 @@ module.zonename = {
 	"The Rock of Desolation",
 }
 
+local _, playerClass = UnitClass("player")
+
 module.defaultDB = {
-	livingstone     = true,
-	dirtmound       = true,
-	dirtmoundmark   = false,
-	flamestrike     = true,
+	boulderalert = false,
+	bouldermark = true,
+	bouldersay = true,
+	livingstone = true,
+	opportunity = true,
+	igniteearth = false,
+	dirtmound = true,
+	dirtmoundmark = false,
+	flamestrike = true,
 	flamestrikemove = true,
-	reform          = true,
+	felheartalert = true,
+	felheartbar = playerClass == "HUNTER" or playerClass == "PRIEST" or playerClass == "WARLOCK",
+	reform = true,
 }
 
 -------------------------------------------------------------------------------
@@ -25,31 +34,62 @@ module.defaultDB = {
 L:RegisterTranslations("enUS", function() return {
 	-- Options
 	cmd = "Rupturan",
-	livingstone_cmd      = "livingstone",
-	livingstone_name     = "Living Stone Stomp",
-	livingstone_desc     = "Show time left until a Living Stone stomp after Crash Landing fades.",
 
-	dirtmound_cmd        = "dirtmound",
-	dirtmound_name       = "Dirt Mound Indicators",
-	dirtmound_desc       = "Warn when Dirt Mound Quake hits you and when one is spawned.",
+	boulderalert_cmd = "boulderalert",
+	boulderalert_name = "Throw Boulder Alert",
+	boulderalert_desc = "Gives a warning message with the target of an incoming Boulder.",
+	
+	bouldermark_cmd = "bouldermark",
+	bouldermark_name = "Throw Boulder Mark",
+	bouldermark_desc = "Mark the target of an incoming Boulder with Moon.",
+	
+	bouldersay_cmd = "bouldersay",
+	bouldersay_name = "Throw Boulder Say",
+	bouldersay_desc = "Alert your surroundings with a /say message if you are the target of an incoming Boulder.",
 
-	dirtmoundmark_cmd    = "dirtmoundmark",
-	dirtmoundmark_name   = "Mark Dirt Mound Target",
-	dirtmoundmark_desc   = "Mark the player Dirt Mound is chasing with a Diamond.",
+	livingstone_cmd = "livingstone",
+	livingstone_name = "Living Stone Stomp",
+	livingstone_desc = "Show time left until a Living Stone stomp after Crash Landing fades.",
 
-	flamestrike_cmd      = "flamestrike",
-	flamestrike_name     = "Flamestrike Cast",
-	flamestrike_desc     = "Warn when Flamestrike (Ignite Rock) is casting.",
+	opportunity_cmd = "opportunity",
+	opportunity_name = "Window of Opportunity",
+	opportunity_desc = "Warns about remaining or incoming Living Stones below 10% boss HP to avoid Explode mechanic (when the boss dies the remaining Living Stones detonate)",
 
-	flamestrikemove_cmd      = "flamestrikemove",
-	flamestrikemove_name     = "Flamestrike Alert",
-	flamestrikemove_desc     = "Warns when you stand in fire (Ignite Rock).",
+	igniteearth_cmd  = "igniteearth",
+	igniteearth_name = "Ignite Earth",
+	igniteearth_desc = "Show cooldown and cast bar for Ignite Earth (P1 flamestrike)",
 
-	reform_cmd           = "reform",
-	reform_name          = "Reform Timer",
-	reform_desc          = "When you kill a Fragment, show show time left until Rupturan will be reformed.",
+	dirtmound_cmd = "dirtmound",
+	dirtmound_name = "Dirt Mound Indicators",
+	dirtmound_desc = "Warn when Dirt Mound Quake hits you and when one is spawned.",
+
+	dirtmoundmark_cmd  = "dirtmoundmark",
+	dirtmoundmark_name = "Mark Dirt Mound Target",
+	dirtmoundmark_desc = "Mark the player Dirt Mound is chasing with a Diamond.",
+
+	flamestrike_cmd = "flamestrike",
+	flamestrike_name = "Flamestrike Cast",
+	flamestrike_desc = "Warn when Flamestrike (Ignite Rock) is casting.",
+
+	flamestrikemove_cmd = "flamestrikemove",
+	flamestrikemove_name = "Flamestrike Alert",
+	flamestrikemove_desc = "Warns when you stand in fire (Ignite Rock).",
+
+	felheartalert_cmd = "felheartalert",
+	felheartalert_name = "Felheart Mana Alert",
+	felheartalert_desc = "Warns when Felheart has >80% mana (5 second CD).",
+
+	felheartbar_cmd = "felheartbar",
+	felheartbar_name = "Felheart Mana Bar",
+	felheartbar_desc = "Adds a continuously updating mana bar for Felheart.",
+
+	reform_cmd = "reform",
+	reform_name = "Reform Timer",
+	reform_desc = "When you kill a Fragment, show show time left until Rupturan will be reformed.",
 
 	-- Bars / Messages
+	bar_ignite_earth_CD  = "Ignite Earth CD",
+	bar_ignite_earth     = "Ignite Earth casting",
 	bar_ignite_rock      = "Flamestrike casting",
 	warn_ignite_rock     = "Incoming!",
 	msg_flamestrike      = "Move out of Flamestrike!",
@@ -59,14 +99,28 @@ L:RegisterTranslations("enUS", function() return {
 	msg_dm_target_near   = "Get away from %s!",
 	msg_dm_target_you    = "Dirt Mound chasing you!",
 	bar_reform           = "Rupturan Reforming",
+	msg_boulder          = "Boulder casting on %s",
+	msg_boulderMiss      = "Boulder missed, no add",
+	say_boulder          = "Boulder incoming on me!",
+	bar_window           = "Window of Opportunity",
+	msg_windowOpen       = "Kill Rupturan! - all Stones dead",
+	msg_windowClosing    = "Stone incoming!",
+	msg_windowClosed     = "Stone alive! DON'T kill Rupturan",
+	msg_felheartMana     = "Felheart at %s%% mana!",
 
 	-- Triggers
 	trigger_start        = "All shall crumble",
 	trigger_phase2       = "Let the cracks of this world destroy you",
 	trigger_boss_dead    = "Perished... To dust",
+	unit_felheart        = "Felheart",
 
+	trigger_tb_cast      = "Rupturan the Broken begins to perform Throw Boulder",
+	trigger_tb_hit       = "Rupturan the Broken's Throw Boulder hits (.+) for",
+	trigger_tb_miss      = "Rupturan the Broken's Throw Boulder missed (.+)%.",
 	trigger_ls_fades     = "Crash Landing fades from Living Stone",
-	trigger_dm_quake     = "Dirt Mound's Quake .?.its (.+) for",
+	trigger_ls_die       = "Living Stone dies",
+	trigger_igniteearth  = "Rupturan the Broken begins to cast Ignite Earth",
+	trigger_dm_quake     = "Dirt Mound's Quake hits you for",
 	trigger_dm_spawn     = "Rupturan commands the earth to crush (.+)!",
 	trigger_dm_die       = "Dirt Mound dies",
 	trigger_flamestrike  = "You are afflicted by Ignite Rock",
@@ -75,35 +129,57 @@ L:RegisterTranslations("enUS", function() return {
 } end)
 
 local timer = {
+	boulderCast = 2,
+	boulderCD = {13,16}, -- lowest 12.6, highest 16.8
 	earthstomp = 5,
+	igniteEarthCast = 3,
+	igniteEarthCD = {15,19}, -- interval based on logs, rarely 14, mostly 16
 	igniteRockCD = {20,53},
 	igniteRock = 3,
 	reform = 10,
 }
 
 local icon = {
-	earthstomp = "Ability_ThunderClap",
-	quake      = "Spell_Nature_Earthquake",
-	igniteRock = "Spell_Fire_SelfDestruct",
-	fire       = "Spell_Fire_Fire", -- warning when standing in Ignite Rock (confusing if same icon as incoming cast)
-	reform     = "Spell_Nature_AstralRecalGroup",
+	earthstomp	= "Ability_ThunderClap",
+	quake		= "Spell_Nature_Earthquake",
+	igniteEarth	= "Spell_Fire_Immolation",
+	igniteRock	= "Spell_Fire_SelfDestruct",
+	fire		= "Spell_Fire_Fire", -- warning when standing in Ignite Rock (confusing if same icon as incoming cast)
+	reform		= "Spell_Nature_AstralRecalGroup",
+	window		= "INV_Misc_PocketWatch_01",
+	felheart	= "Spell_Holy_PrayerOfFortitude",
 }
 
 local syncName = {
-	earthstomp   = "RupturanEarthStomp"..module.revision,
-	igniteRock   = "RupturanIgniteRock"..module.revision,
-	dm_spawn     = "RupturanDirtMoundSpawn"..module.revision,
-	phase2       = "RupturanPhaseTwo"..module.revision,
-	reform       = "RupturanReform"..module.revision,
+	earthstomp = "RupturanEarthStomp"..module.revision,
+	igniteEarth = "RupturanIgniteEarth"..module.revision,
+	igniteRock = "RupturanIgniteRock"..module.revision,
+	dm_spawn = "RupturanDirtMoundSpawn"..module.revision,
+	phase2 = "RupturanPhaseTwo"..module.revision,
+	reform = "RupturanReform"..module.revision,
+	throwBoulderCast = "RupturanThrowBoulderCast"..module.revision,
+	throwBoulderOutcome = "RupturanThrowBoulderOutcome"..module.revision,
+	livingStoneDeath = "RupturanLivingStoneDeath"..module.revision,
 }
 
 local spellIds = {
-	igniteRock = 51298,
-	reform     = 51299,
+	igniteEarth		= 52040,
+	throwBoulder	= 51289,
+	igniteRock		= 51298,
+	reform			= 51299,
 }
 
--- keep track of which player currently has popcorn
+local guid = {
+	rupturan = "0xF13000EA39073D35",
+	felheart = nil,
+}
+
+-- keep track of players to later reset raid marks, and active Living Stones
 local mound_chasing = nil
+local boulder_victim = nil
+local last_boulder = 0
+local active_living_stones = 0
+local last_mana_warn = 0
 
 -------------------------------------------------------------------------------
 --  Initialization
@@ -115,8 +191,10 @@ function module:OnEnable()
 	-- Living Stone stomp countdown
 	self:RegisterEvent("CHAT_MSG_SPELL_AURA_GONE_OTHER", "Event")
 
-	-- Quake damage landed on you
-	self:RegisterEvent("CHAT_MSG_SPELL_CREATURE_VS_SELF_DAMAGE", "Event")
+	-- Quake damage, Throw Boulder
+	self:RegisterEvent("CHAT_MSG_SPELL_CREATURE_VS_SELF_DAMAGE", "SpellEvent")
+	self:RegisterEvent("CHAT_MSG_SPELL_CREATURE_VS_PARTY_DAMAGE", "SpellEvent")
+	self:RegisterEvent("CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE", "SpellEvent") -- also non-SuperWoW Ignite Earth & Ignite Rock cast
 
 	-- Dirt Mound spawn target announcement (emote)
 	self:RegisterEvent("CHAT_MSG_RAID_BOSS_EMOTE", "Event")
@@ -130,14 +208,18 @@ function module:OnEnable()
 	if SUPERWOW_VERSION or SetAutoloot then
 		self:RegisterEvent("UNIT_CASTEVENT")
 	else
-		self:RegisterEvent("CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE", "CastEvent") -- Ignite Rock cast
-		self:RegisterEvent("CHAT_MSG_SPELL_CREATURE_VS_CREATURE_BUFF", "CastEvent") -- Reform cast
+		self:RegisterEvent("CHAT_MSG_SPELL_CREATURE_VS_CREATURE_BUFF", "SpellEvent") -- Reform cast
 	end
 
 	self:ThrottleSync(2, syncName.earthstomp)
+	self:ThrottleSync(4, syncName.igniteEarth)
+	self:ThrottleSync(1, syncName.igniteRock)
 	self:ThrottleSync(2, syncName.dm_spawn)
 	self:ThrottleSync(2, syncName.phase2)
 	self:ThrottleSync(1, syncName.reform)
+	self:ThrottleSync(5, syncName.throwBoulderCast)
+	self:ThrottleSync(5, syncName.throwBoulderOutcome)
+	self:ThrottleSync(0.5, syncName.livingStoneDeath)
 end
 
 -- function module:OnSetup()
@@ -145,12 +227,21 @@ end
 
 function module:OnEngage()
 	mound_chasing = nil
+	boulder_victim = nil
+	last_boulder = 0
+	active_living_stones = 0
+	last_mana_warn = 0
 end
 
 function module:OnDisengage()
 	-- clean up bars
 	self:RemoveBar(L.bar_ls_earthstomp)
+	self:CancelDelayedBar(L.bar_ignite_earth_CD)
+	self:RemoveBar(L.bar_ignite_earth_CD)
 	self:RestorePreviousRaidTargetForPlayer(mound_chasing)
+	self:RestorePreviousRaidTargetForPlayer(boulder_victim)
+	self:CancelScheduledEvent("RupturanFindFelheart")
+	self:CancelScheduledEvent("RupturanCheckFelheart")
 end
 
 -------------------------------------------------------------------------------
@@ -163,18 +254,11 @@ function module:Event(msg)
 		self:Sync(syncName.earthstomp)
 		return
 	end
-	if self.db.profile.dirtmound then
-		-- Quake hit on you
-		if string.find(msg, L.trigger_dm_quake) then
-			self:DirtMoundQuake() -- personal damage, no syncing
-			return
-		end
-		-- Dirt Mound spawn emote: capture player name
-		local _,_,player = string.find(msg, L.trigger_dm_spawn)
-		if player then
-			self:Sync(syncName.dm_spawn .. " " .. player)
-			return
-		end
+	-- Dirt Mound spawn emote: capture player name
+	local _,_,player = string.find(msg, L.trigger_dm_spawn)
+	if player then
+		self:Sync(syncName.dm_spawn .. " " .. player)
+		return
 	end
 	if string.find(msg, L.trigger_phase2) then
 		self:Sync(syncName.phase2)
@@ -191,20 +275,86 @@ function module:Event(msg)
 end
 
 function module:UNIT_CASTEVENT(caster,target,action,spellId,castTime)
+	if spellId == spellIds.igniteEarth and action == "START" then
+		self:Sync(syncName.igniteEarth .. " " .. (castTime / 1000))
+		return
+	end
+	if spellId == spellIds.throwBoulder and action == "START" then
+		self:Sync(syncName.throwBoulderCast .. " " .. UnitName(target))
+		return
+	end
 	if spellId == spellIds.igniteRock and action == "START" then
 		self:Sync(syncName.igniteRock .. " " .. (castTime / 1000))
+		return
 	end
 	if spellId == spellIds.reform and action == "START" then
 		self:Sync(syncName.reform)
+		return
 	end
 end
 
-function module:CastEvent(msg)
-	if string.find(msg, L.trigger_igniterock) then
-		self:Sync(syncName.igniteRock .. " " .. timer.igniteRock)
+function module:SpellEvent(msg)
+	-- non-SuperWoW Ignite Earth cast
+	if string.find(msg, L.trigger_igniteearth) and not SUPERWOW_VERSION then
+		self:Sync(syncName.igniteEarth .. " " .. timer.igniteEarthCast)
+		return
 	end
+
+	-- Quake hit on you
+	if string.find(msg, L.trigger_dm_quake) then
+		self:DirtMoundQuake() -- personal damage, no syncing
+		return
+	end
+
+	-- Throw Boulder cast
+	if string.find(msg, L.trigger_tb_cast) and not SUPERWOW_VERSION then
+		self:ScheduleEvent("RupturanDelayedTargetCheck", self.DelayedTargetCheck, 0.2, self)
+		return
+	end
+	
+	-- Throw Boulder hit
+	local _,_,player = string.find(msg, L.trigger_tb_hit)
+	if player then
+		player = player == "you" and UnitName("player") or player
+		if player == boulder_victim then
+			self:Sync(syncName.throwBoulderOutcome .. " hit")
+		end
+		return
+	end
+	
+	-- Throw Boulder miss
+	local _,_,player = string.find(msg, L.trigger_tb_miss)
+	if player then
+		player = player == "you" and UnitName("player") or player
+		if player == boulder_victim then
+			self:Sync(syncName.throwBoulderOutcome .. " miss")
+		end
+		return
+	end
+
+	-- non-SuperWoW Ignite Rock cast
+	if string.find(msg, L.trigger_igniterock) and not SUPERWOW_VERSION  then
+		self:Sync(syncName.igniteRock .. " " .. timer.igniteRock)
+		return
+	end
+
+	-- non-SuperWoW Reform cast
 	if string.find(msg, L.trigger_reform) then
 		self:Sync(syncName.reform)
+		return
+	end
+end
+
+function module:OnEnemyDeath(msg)
+	if string.find(msg, L.trigger_ls_die) then
+		self:Sync(syncName.livingStoneDeath)
+	end
+end
+
+function module:DelayedTargetCheck()
+	local target = BigWigs:GetTargetByName(module.translatedName, 1)
+	if target then
+		self:Sync(syncName.throwBoulderCast .. " " .. target)
 	end
 end
 
@@ -215,6 +365,10 @@ end
 function module:BigWigs_RecvSync(sync, rest, nick)
 	if sync == syncName.earthstomp then
 		self:CrashLandingFades()
+
+	elseif sync == syncName.igniteEarth and rest then
+		local castTime = tonumber(rest)
+		self:IgniteEarth(castTime)
 
 	elseif sync == syncName.dm_spawn and rest then
 		self:DirtMoundSpawn(rest)
@@ -228,6 +382,16 @@ function module:BigWigs_RecvSync(sync, rest, nick)
 
 	elseif sync == syncName.reform then
 		self:Reform()
+
+	elseif sync == syncName.throwBoulderCast and rest then
+		self:ThrowBoulder(rest)
+
+	elseif sync == syncName.throwBoulderOutcome and rest then
+		self:ThrowBoulderOutcome(rest)
+
+	elseif sync == syncName.livingStoneDeath then
+		active_living_stones = active_living_stones - 1
+		self:CheckOpportunity()
 	end
 end
 
@@ -236,6 +400,21 @@ function module:CrashLandingFades()
 
 	self:Sound("Alarm")
 	self:Bar(L.bar_ls_earthstomp, timer.earthstomp, icon.earthstomp)
+end
+
+function module:IgniteEarth(castTime)
+	if not self.db.profile.igniteearth then return end
+	castTime = castTime or timer.igniteEarthCast
+
+	-- Remove any ongoing CD bar
+	self:CancelDelayedBar(L.bar_ignite_earth_CD)
+	self:RemoveBar(L.bar_ignite_earth_CD)
+
+	-- Put up cast bar
+	self:Bar(L.bar_ignite_earth, castTime, icon.igniteEarth)
+	self:Sound("Info")
+	-- Schedule CD bar to show after cast finishes
+	self:DelayedIntervalBar(castTime, L.bar_ignite_earth_CD, timer.igniteEarthCD[1]-castTime, timer.igniteEarthCD[2]-castTime, icon.igniteEarth, true, "ItemQuality0")
 end
 
 function module:DirtMoundQuake()
@@ -273,9 +452,15 @@ function module:DirtMoundSpawn(player)
 end
 
 function module:Phase2()
+	-- cancel P1 bars
+	self:CancelDelayedBar(L.bar_ignite_earth_CD)
+	self:RemoveBar(L.bar_ignite_earth_CD)
+	self:RemoveBar(L.bar_window)
 	-- clear popcorn mark
 	self:RestorePreviousRaidTargetForPlayer(mound_chasing)
 	mound_chasing = nil
+	-- start looking for Felheart
+	self:FindFelheart()
 end
 
 function module:IgniteRock(castTime)
@@ -293,6 +478,100 @@ function module:Reform()
 	self:Bar(L.bar_reform, timer.reform, icon.reform)
 end
 
+function module:ThrowBoulder(targetName)
+	boulder_victim = targetName
+	last_boulder = GetTime()
+	
+	if self.db.profile.boulderalert then
+		self:Message(string.format(L.msg_boulder, targetName), "Attention")
+	end
+
+	if self.db.profile.bouldermark then
+		self:SetRaidTargetForPlayer(targetName, "Moon")
+	end
+
+	if targetName == UnitName("player") and self.db.profile.bouldersay then
+		SendChatMessage(L.say_boulder, "SAY")
+	end
+	
+	if self:GetHealth() <= 15 and self.db.profile.opportunity then
+		self:Bar(L.bar_window, timer.boulderCast - 0.3, icon.window, true, "White")
+		if not self.db.profile.boulderalert then -- don't double up on messages
+			self:Message(L.msg_windowClosing, "Urgent", true, "Beware")
+		end
+	end
+end
+
+function module:ThrowBoulderOutcome(outcome)
+	if outcome == "hit" then
+		active_living_stones = active_living_stones + 1
+		if self:GetHealth() <= 15 and self.db.profile.opportunity then
+			self:RemoveBar(L.bar_window)
+			self:Message(L.msg_windowClosed, "Important", true, "Alert")
+		end
+	end
+
+	if outcome == "miss" then
+		if self.db.profile.boulderalert then
+			self:Message(L.msg_boulderMiss, "Positive", true, "Long")
+		end
+		if boulder_victim == UnitName("player") and self.db.profile.bouldersay then
+			SendChatMessage(L.msg_boulderMiss, "SAY")
+		end
+		self:CheckOpportunity()
+	end
+
+	-- clear victim
+	self:RestorePreviousRaidTargetForPlayer(boulder_victim)
+	boulder_victim = nil
+end
+
+function module:GetHealth()
+	local health = 100 -- set to 9 to test window of opportunity
+	if UnitExists(guid.rupturan) then
+		health = math.floor((UnitHealth(guid.rupturan)/UnitHealthMax(guid.rupturan)) * 100)
+	end
+	return health
+end
+
+function module:CheckOpportunity()
+	if self:GetHealth() > 15 or (not self.db.profile.opportunity) then return end
+
+	local windowHigh = last_boulder + timer.boulderCD[2] + timer.boulderCast - GetTime()
+	if active_living_stones == 0 and windowHigh > 3 then
+		self:Bar(L.bar_window, windowHigh, icon.window, true, "White")
+		self:Message(L.msg_windowOpen, "Positive")
+	end
+end
+
+function module:FindFelheart()
+	local found = BigWigs:GetGUIDByName(L.unit_felheart, 1)
+	if found then
+		guid.felheart = found
+		if self.db.profile.felheartalert then
+			self:ScheduleRepeatingEvent("RupturanCheckFelheart", self.CheckFelheart, 0.5, self)
+		end		
+		if self.db.profile.felheartbar then
+			self:MonitorBar("Felheart Mana", icon.felheart, guid.felheart, "mana", L.unit_felheart)
+		end
+	else
+		self:ScheduleEvent("RupturanFindFelheart", self.FindFelheart, 0.5, self)
+	end
+end
+
+function module:CheckFelheart()
+	if self.db.profile.felheartalert and guid.felheart and UnitExists(guid.felheart) then
+		local percent = math.ceil(UnitMana(guid.felheart)/UnitManaMax(guid.felheart) * 100)
+		if percent >= 80 and last_mana_warn + 5 < GetTime() then
+			self:Message(string.format(L.msg_felheartMana, percent), "Core", true, "Beware")
+			last_mana_warn = GetTime()
+		end
+	else
+		-- if alert disabled or Felheart doesn't currently exist stop checking
+		self:CancelScheduledEvent("RupturanCheckFelheart")
+	end
+end
+
 -------------------------------------------------------------------------------
 --  Testing
 -------------------------------------------------------------------------------
@@ -300,20 +579,40 @@ end
 function module:Test()
 	local print = function (s) DEFAULT_CHAT_FRAME:AddMessage(s) end
 	BigWigs:EnableModule(self:ToString())
+	self:RegisterEvent("UNIT_CASTEVENT")
 
 	local player = UnitName("player")
+	local _,playerGuid = UnitExists("player")
+	local raid1 = UnitName("player") or "Raid1"
+	local raid2 = UnitName("player") or "Raid2"
 	local tests = {
 		-- after  1s, simulate the “Crash Landing fades from Living Stone” fade event
 		{0,
 		"Engage:",
 		"CHAT_MSG_MONSTER_YELL",
 		"All shall crumble... To dust."},
-		{3,
+		{0.5,
+		"First Ignite Earth:",
+		"CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE",
+		"Rupturan the Broken begins to cast Ignite Earth."},
+		{1,
+		"First Throw Boulder:",
+		"UNIT_CASTEVENT",
+		{"caster",playerGuid,"START",spellIds.throwBoulder,2000} },
+		{4,
+		"Boulder Hits:",
+		"CHAT_MSG_SPELL_CREATURE_VS_SELF_DAMAGE",
+		"Rupturan the Broken's Throw Boulder hits you for 1351."},
+		{5,
 		"Crash Land test:",
 		"CHAT_MSG_SPELL_AURA_GONE_OTHER",
 		"Crash Landing fades from Living Stone."},
+		{7,
+		"Living Stone dies:",
+		"CHAT_MSG_COMBAT_HOSTILE_DEATH",
+		"Living Stone dies."},
 		-- after  2s, simulate the quake damage event
-		{8,
+		{11,
 		"Quake damage test:",
 		"CHAT_MSG_SPELL_CREATURE_VS_SELF_DAMAGE",
 		"Dirt Mound's Quake hits you for 717 Nature damage."},
@@ -322,15 +621,26 @@ function module:Test()
 		"Emote player test:",
 		"CHAT_MSG_RAID_BOSS_EMOTE",
 		"Rupturan commands the earth to crush "..player.."!"},
+		{14,
+		"Second Throw Boulder:",
+		"UNIT_CASTEVENT",
+		{"caster",playerGuid,"START",spellIds.throwBoulder,2000} },
 		{16,
+		"Boulder Misses:",
+		"CHAT_MSG_SPELL_CREATURE_VS_SELF_DAMAGE",
+		"Rupturan the Broken's Throw Boulder missed you."},
+		{17,
 		"Emote raid1 test:",
 		"CHAT_MSG_RAID_BOSS_EMOTE",
-		"Rupturan commands the earth to crush "..UnitName("raid1").."!"},
-		-- after  4s, simulate the same on “Bob”
-		{19,
+		"Rupturan commands the earth to crush "..raid1.."!"},
+		{18,
+		"Second Ignite Earth:",
+		"CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE",
+		"Rupturan the Broken begins to cast Ignite Earth."},
+		{20,
 		"Emote raid2 test:",
 		"CHAT_MSG_RAID_BOSS_EMOTE",
-		"Rupturan commands the earth to crush "..UnitName("raid2").."!"},
+		"Rupturan commands the earth to crush "..raid2.."!"},
 		{22,
 		"Phase 2 change:",
 		"CHAT_MSG_MONSTER_YELL",
@@ -389,3 +699,6 @@ function module:Test()
 	return true
 end
 -- /run BigWigs:GetModule("Rupturan the Broken"):Test()
+
+-- to test the Window of Opportunity functionality set health inside GetHealth() temporarily to 9
+-- no test for Felheart mana alert and mana bar available

--- a/Raids/KarazhanUpper/SanvTasdal.lua
+++ b/Raids/KarazhanUpper/SanvTasdal.lua
@@ -3,7 +3,7 @@ local module, L = BigWigs:ModuleDeclaration("Sanv Tas'dal", "Karazhan")
 -- module variables
 module.revision = 30002
 module.enabletrigger = module.translatedName
-module.toggleoptions = { "phaseshifted", "overflowinghatred", "addphase", "bosskill" }
+module.toggleoptions = { "phaseshifted", "overflowinghatred", "addphase", "curseoftherift", "keepcurse", "riftfeedback", "bosskill" }
 module.zonename = {
 	AceLibrary("AceLocale-2.2"):new("BigWigs")["Tower of Karazhan"],
 	AceLibrary("Babble-Zone-2.2")["Tower of Karazhan"],
@@ -16,6 +16,9 @@ module.defaultDB = {
 	phaseshifted = true,
 	overflowinghatred = true,
 	addphase = true,
+	curseoftherift = false,
+	keepcurse = true,
+	riftfeedback = false,
 }
 
 -- localization
@@ -34,6 +37,18 @@ L:RegisterTranslations("enUS", function()
 		addphase_cmd = "addphase",
 		addphase_name = "Add-Phase Timer",
 		addphase_desc = "Shows a timer bar for the add phase at 40%",
+		
+		curseoftherift_cmd = "curseoftherift",
+		curseoftherift_name = "Curse Timer",
+		curseoftherift_desc = "Shows a timer for repeated Curse of the Rift applications",
+
+		keepcurse_cmd = "keepcurse",
+		keepcurse_name = "Curse Alert",
+		keepcurse_desc = "Shows a message to maintain Curse of the Rift on the last Curse application before the next Rift Feedback",
+
+		riftfeedback_cmd = "riftfeedback",
+		riftfeedback_name = "Rift Feedback CD",
+		riftfeedback_desc = "Shows a timer for the minimum CD of Rift Feedback",
 
 
 		trigger_phaseShiftedYou = "You are afflicted by Phase Shifted",
@@ -53,9 +68,17 @@ L:RegisterTranslations("enUS", function()
 		msg_portalsOpen = "80% HP - Portals Opening",
 		msg_addPhase = "40% HP - Add Phase",
 		bar_addPhase = "Add Phase",
-		
+
 		trigger_Enrage = "Sanv Tas'dal gains Enrage",
 		msg_Enrage = "Enrage - Tranq now!",
+
+		trigger_curseRift = "afflicted by Curse of the Rift",
+		trigger_curseRiftImmune = "Curse of the Rift fails%.", -- triggers only on raid member immunity messages. Does not account for "Sanv Tas'dal's Curse of the Rift failed. You are immune." but it shouldn't be necessary
+		bar_curseRift = "next Curse",
+		
+		trigger_riftFeedback = "Sanv Tas'dal's Rift Feedback",
+		bar_riftFeedback = "Rift Feedback CD",
+		msg_keepCurse = "Keep the Curse - Feedback soon!",
 	}
 end)
 
@@ -64,22 +87,28 @@ local timer = {
 	phaseShiftedDuration = 25,
 	overflowingHatredCast = 6,
 	addPhase = 50,
+	curseRift = 15, -- very reliable 15-16s interval
+	riftFeedback = 45, -- lots of 47s and 53s cast-to-cast observed in logs; going with minimum CD because the only relevant info is when to keep Curse
 }
 
 local icon = {
 	phaseShifted = "Spell_Shadow_AbominationExplosion",
 	overflowingHatred = "Spell_Fire_Incinerate",
-	addPhase = "Spell_Arcane_TeleportOrgrimmar"
-}
-
-local color = {
-	red = "Red",
+	addPhase = "Spell_Arcane_TeleportOrgrimmar",
+	curseRift = "Spell_Shadow_GrimWard",
+	riftFeedback = "Spell_Nature_Wispsplode",
 }
 
 local syncName = {
 	phaseShifted = "SanvTasdalPhaseShifted" .. module.revision,
 	phaseShiftedFade = "SanvTasdalPhaseShiftedFade" .. module.revision,
 	overflowingHatred = "SanvTasdalOverflowingHatred" .. module.revision,
+	curseRift = "SanvTasdalCurseRift" .. module.revision,
+	riftFeedback = "SanvTasdalRiftFeedback" .. module.revision,
+}
+
+local guid = {
+	sanv = "0xF13000EA4D05DA44",
 }
 
 function module:OnEnable()
@@ -89,29 +118,31 @@ function module:OnEnable()
 	self:RegisterEvent("CHAT_MSG_SPELL_AURA_GONE_SELF")
 	self:RegisterEvent("CHAT_MSG_SPELL_AURA_GONE_OTHER")
 
-	self:RegisterEvent("CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE", "BeginsCastEvent")
-	self:RegisterEvent("CHAT_MSG_SPELL_CREATURE_VS_CREATURE_BUFF", "BeginsCastEvent")
+	self:RegisterEvent("CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE", "CastEvent")
+	self:RegisterEvent("CHAT_MSG_SPELL_CREATURE_VS_CREATURE_BUFF", "CastEvent")
 	
 	self:RegisterEvent("CHAT_MSG_SPELL_PERIODIC_CREATURE_BUFFS")
 
 	self:ThrottleSync(3, syncName.phaseShifted)
 	self:ThrottleSync(3, syncName.phaseShiftedFade)
 	self:ThrottleSync(3, syncName.overflowingHatred)
+	self:ThrottleSync(3, syncName.curseRift)
+	self:ThrottleSync(3, syncName.riftFeedback)
 end
 
 function module:OnSetup()
-	self.bossHealth = 100
 	self.hitEighty = nil
-	self.hitFourty = nil
+	self.hitForty = nil
+	self.nextFeedback = nil
 end
 
 function module:OnEngage()
-	self.bossHealth = 100
 	self.hitEighty = nil
-	self.hitFourty = nil
+	self.hitForty = nil
+	self.nextFeedback = nil
 	
 	-- Start health monitoring
-	self:ScheduleRepeatingEvent("CheckBossHealth", self.CheckBossHealth, 1, self)
+	self:ScheduleRepeatingEvent("CheckBossHealth", self.CheckBossHealth, 0.5, self)
 end
 
 function module:OnDisengage()
@@ -130,11 +161,18 @@ function module:AfflictionEvent(msg)
 			self:Sync(syncName.phaseShifted .. " " .. player)
 		end
 	end
+	
+	-- Curse of the Rift
+	if string.find(msg, L["trigger_curseRift"]) or string.find(msg, L["trigger_curseRiftImmune"])then
+		self:Sync(syncName.curseRift)
+	end
 end
 
-function module:BeginsCastEvent(msg)
+function module:CastEvent(msg)
 	if string.find(msg, L["trigger_overflowingHatredCast"]) then
 		self:Sync(syncName.overflowingHatred)
+	elseif string.find(msg, L["trigger_riftFeedback"]) then
+		self:Sync(syncName.riftFeedback)
 	end
 end
 
@@ -169,6 +207,10 @@ function module:BigWigs_RecvSync(sync, rest, nick)
 		self:PhaseShiftedFade(rest)
 	elseif sync == syncName.overflowingHatred then
 		self:OverflowingHatred()
+	elseif sync == syncName.curseRift then
+		self:CurseOfTheRift()
+	elseif sync == syncName.riftFeedback then
+		self:RiftFeedback()
 	end
 end
 
@@ -193,36 +235,53 @@ function module:OverflowingHatred()
 	if self.db.profile.overflowinghatred then
 		self:Message(L["msg_overflowingHatred"], "Important", nil, "Alarm")
 		self:WarningSign(icon.overflowingHatred, 3, true, L["warn_overflowingHatred"])
-		self:Bar(L["bar_overflowingHatredCast"], timer.overflowingHatredCast, icon.overflowingHatred, true, color.red)
+		self:Bar(L["bar_overflowingHatredCast"], timer.overflowingHatredCast, icon.overflowingHatred, true, "Red")
 	end
 end
 
 function module:CheckBossHealth()
-	for i = 1, GetNumRaidMembers() do
-		local targetString = "raid" .. i .. "target"
-		local targetName = UnitName(targetString)
+	if UnitExists(guid.sanv) then
+		local percent = UnitHealth(guid.sanv)/UnitHealthMax(guid.sanv) * 100
 
-		if targetName == module.translatedName then
-			local health = UnitHealth(targetString)
-			local healthMax = UnitHealthMax(targetString)
-
-			if health > 0 and healthMax > 0 then
-				self.bossHealth = math.ceil((health / healthMax) * 100)
-
-				if self.bossHealth <= 80 and not self.hitEighty then
-					self:Message(L["msg_portalsOpen"], "Attention", nil, "Alarm")
-					self.hitEighty = true
-				end
-				if self.bossHealth <= 40 and not self.hitFourty then
-					self:Message(L["msg_addPhase"], "Attention", nil, "Alarm")
-					if self.db.profile.addphase then
-						self:Bar(L["bar_addPhase"], timer.addPhase, icon.addPhase, true, "blue")
-					end
-					self.hitFourty = true
-				end
-				break
-			end
+		if percent <= 80 and not self.hitEighty then
+			self:Message(L["msg_portalsOpen"], "Attention", nil, "Alarm")
+			self.hitEighty = true
 		end
+		if percent <= 40 and not self.hitForty then
+			self:AddPhase()
+			self.hitForty = true
+			self:CancelScheduledEvent("CheckBossHealth")
+		end
+	end
+end
+
+function module:AddPhase()
+	self:Message(L["msg_addPhase"], "Attention", nil, "Alarm")
+	self:RemoveBar(L["bar_curseRift"])
+	self:RemoveBar(L["bar_overflowingHatredCast"])
+	if self.db.profile.addphase then
+		self:Bar(L["bar_addPhase"], timer.addPhase, icon.addPhase, true, "blue")
+	end
+	self.nextFeedback = GetTime() + timer.addPhase + 10
+end
+
+function module:CurseOfTheRift()
+	if self.db.profile.curseoftherift then
+		self:RemoveBar(L["bar_curseRift"])
+		self:Bar(L["bar_curseRift"], timer.curseRift, icon.curseRift, true, "White")
+	end
+
+	if self.nextFeedback and self.db.profile.keepcurse and self.nextFeedback - GetTime() < timer.curseRift then
+		self:Message(L["msg_keepCurse"], "Positive", nil, "Info")
+	end
+end
+
+function module:RiftFeedback()
+	self.nextFeedback = GetTime() + timer.riftFeedback
+	
+	if self.db.profile.riftfeedback then
+		self:RemoveBar(L["bar_riftFeedback"])
+		self:Bar(L["bar_riftFeedback"], timer.riftFeedback, icon.riftFeedback, true, "Blue")	
 	end
 end
 
@@ -254,13 +313,6 @@ function module:Test()
 			module:CHAT_MSG_SPELL_AURA_GONE_OTHER(msg)
 		end },
 
-		-- Add Overflowing Hatred test
-		{ time = 12, func = function()
-			local msg = "Sanv Tas'dal begins to cast Overflowing Hatred"
-			print("Test: " .. msg)
-			module:BeginsCastEvent(msg)
-		end },
-
 		{ time = 15, func = function()
 			local msg = "You are afflicted by Phase Shifted"
 			print("Test: " .. msg)
@@ -271,13 +323,6 @@ function module:Test()
 			local msg = "Phase Shifted fades from you"
 			print("Test: " .. msg)
 			module:CHAT_MSG_SPELL_AURA_GONE_SELF(msg)
-		end },
-
-		-- Add another Overflowing Hatred test
-		{ time = 27, func = function()
-			local msg = "Sanv Tas'dal begins to cast Overflowing Hatred"
-			print("Test: " .. msg)
-			module:BeginsCastEvent(msg)
 		end },
 
 		{ time = 30, func = function()
@@ -292,13 +337,82 @@ function module:Test()
 			module:CHAT_MSG_COMBAT_FRIENDLY_DEATH(msg)
 		end },
 
+		-- Curse of the Rift when others have FAP active
+		{ time = 7, func = function() 
+			local msg = "Sanv Tas'dal's Curse of the Rift fails. "..testPlayerName2.." is immune."
+			print("Test: " .. msg)
+			module:AfflictionEvent(msg)
+		end },
+
+		-- Test Curse of the Rift when others get it
+		{ time = 22, func = function() 
+			local msg = testPlayerName1 .. " is afflicted by Curse of the Rift"
+			print("Test: " .. msg)
+			module:AfflictionEvent(msg)
+		end },
+
+		-- Curse of the Rift when the player gets it
+		{ time = 37, func = function()
+			local msg = "You are afflicted by Curse of the Rift"
+			print("Test: " .. msg)
+			module:AfflictionEvent(msg)
+		end },
+
+		-- Curse of the Rift after Add Phase
+		{ time = 84, func = function() 
+			local msg = "Sanv Tas'dal's Curse of the Rift fails. "..testPlayerName2.." is immune."
+			print("Test: " .. msg)
+			module:AfflictionEvent(msg)
+		end },
+
+		-- Add Overflowing Hatred test
+		{ time = 12, func = function()
+			local msg = "Sanv Tas'dal begins to cast Overflowing Hatred"
+			print("Test: " .. msg)
+			module:CastEvent(msg)
+		end },
+
+		-- Add another Overflowing Hatred test
+		{ time = 27, func = function()
+			local msg = "Sanv Tas'dal begins to cast Overflowing Hatred"
+			print("Test: " .. msg)
+			module:CastEvent(msg)
+		end },
+
+		{ time = 29, func = function()
+			print("Test: Forcing Add Phase (40%)")
+			module:AddPhase()
+			module.hitForty = true
+		end },
+
 		{ time = 36, func = function()
 			local msg = "Sanv Tas'dal gains Enrage."
 			print("Test: " .. msg)
 			module:CHAT_MSG_SPELL_PERIODIC_CREATURE_BUFFS(msg)
 		end },
 
-		{ time = 40, func = function()
+		-- Rift Feedback hits
+		{ time = 42, func = function()
+			local msg = "Sanv Tas'dal's Rift Feedback hits "..testPlayerName1.." for 0 Arcane damage. (3000 resisted)"
+			print("Test: " .. msg)
+			module:CastEvent(msg)
+		end },
+		
+		-- Test Rift Feedback resists
+		{ time = 45, func = function()
+			local msg = "Sanv Tas'dal's Rift Feedback was resisted by " .. testPlayerName2
+			print("Test: " .. msg)
+			module:CastEvent(msg)
+		end },
+		
+		-- Rift Feedback after Add Phase
+		{ time = 88, func = function()
+			local msg = "Sanv Tas'dal's Rift Feedback was resisted by " .. testPlayerName1
+			print("Test: " .. msg)
+			module:CastEvent(msg)
+		end },
+
+		{ time = 95, func = function()
 			print("Test: Disengage")
 			module:Disengage()
 		end },

--- a/Raids/MC/Thaurissan.lua
+++ b/Raids/MC/Thaurissan.lua
@@ -2,10 +2,18 @@ local module, L = BigWigs:ModuleDeclaration("Sorcerer-Thane Thaurissan", "Molten
 
 module.revision = 30003
 module.enabletrigger = module.translatedName
-module.toggleoptions = { "runetimers", "runeofdetonation", "runeofcombustion", "bosskill" }
+module.toggleoptions = {"runetimers", "runeofdetonation", "runeofcombustion", "floorwarn", "bosskill"}
 module.zonename = {
 	AceLibrary("AceLocale-2.2"):new("BigWigs")["Molten Core"],
 	AceLibrary("Babble-Zone-2.2")["Molten Core"],
+}
+
+-- module defaults
+module.defaultDB = {
+	runetimers = true,
+	runeofdetonation = true,
+	runeofcombustion = true,
+	floorwarn = true,
 }
 
 L:RegisterTranslations("enUS", function() return {
@@ -17,11 +25,15 @@ L:RegisterTranslations("enUS", function() return {
 
 	runeofdetonation_cmd = "runeofdetonation",
 	runeofdetonation_name = "Rune of Detonation Alert",
-	runeofdetonation_desc = "Personal alert when you have both Rune of Detonation and Rune of Power",
+	runeofdetonation_desc = "Personal alert for Rune of Detonation whether you are correctly outside of the Rune of Power (floor zone)",
 
 	runeofcombustion_cmd = "runeofcombustion",
 	runeofcombustion_name = "Rune of Combustion Alert",
-	runeofcombustion_desc = "Personal alert when you have Rune of Combustion and not Rune of Power",
+	runeofcombustion_desc = "Personal alert for Rune of Combustion whether you are correctly inside of the Rune of Power (floor zone)",
+
+	floorwarn_cmd = "floorwarn",
+	floorwarn_name = "Rune of Power Warning",
+	floorwarn_desc = "Warns shortly before Rune of Power (floor zone) is recast in a new location (every 25% of boss HP); must be enabled before pull",
 
 	trigger_detonation = "afflicted by Rune of Detonation",
 	trigger_combustion = "afflicted by Rune of Combustion",
@@ -32,21 +44,25 @@ L:RegisterTranslations("enUS", function() return {
 	trigger_runeOfPowerYou = "You are afflicted by Rune of Power",
 	trigger_runeOfPowerFade = "Rune of Power fades from you",
 
-	msg_detonation = "Get/Stay out of the Zone - Rune of Detonation",
-	msg_combustion = "Get/Stay in the Zone - Rune of Combustion",
-	msg_combustion_out_of_zone = "Get back into the Zone!!!",
-	msg_detonation_in_zone = "Get back out of the Zone!!!",
+	msg_detonation = "Move out of the Zone - Rune of Detonation",
+	msg_detonationSolved = "Stay out of the Zone - Rune of Detonation",
+	msg_combustion = "Get into the Zone - Rune of Combustion",
+	msg_combustionSolved = "Stay in the Zone - Rune of Combustion",
 	bar_runeDetonation = "Detonation (move out)",
 	bar_runeCombustion = "Combustion (get in)",
-	bar_detonationNext = "Next Detonation Rune",
-	bar_combustionNext = "Next Combustion Rune",
-	warn_detonation = "MOVE_OUT",
-	warn_combustion = "GET_IN",
+	bar_detonationNext = "next Detonation Rune",
+	bar_combustionNext = "next Combustion Rune",
+	warn_detonation = "MOVE OUT",
+	warn_combustion = "GET IN",
+	
+	msg_floorwarn = "Floor Zone moving soon! %s%%",
 } end)
 
 local hasRuneOfDetonation = false
 local hasRuneOfPower = false
 local hasRuneOfCombustion = false
+local nextFloorWarn = 75
+local floorWarn = 3 -- how many % of HP before the recast the warning triggers
 
 local timer = {
 	runeCooldown = { 18, 22 }, -- average of 20
@@ -65,6 +81,9 @@ local syncName = {
 	runeDetonation = "MCThaurissanDetonation" .. module.revision,
 	runeCombustion = "MCThaurissanCombusion" .. module.revision,
 }
+local guid = {
+	thaurissan = "0xF13000E12A278C49",
+}
 
 function module:OnEnable()
 	self:RegisterEvent("CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE", "Event")
@@ -80,15 +99,20 @@ function module:OnSetup()
 	hasRuneOfDetonation = false
 	hasRuneOfPower = false
 	hasRuneOfCombustion = false
+	nextFloorWarn = 75
 end
 
 function module:OnEngage()
 	hasRuneOfDetonation = false
 	hasRuneOfPower = false
 	hasRuneOfCombustion = false
+	nextFloorWarn = 75
 
 	if self.db.profile.runetimers then
 		self:IntervalBar(L["bar_detonationNext"], timer.runeCooldown[1], timer.runeCooldown[2], icon.runeDetonation, true, color.runeUpcoming)
+	end
+	if self.db.profile.floorwarn then
+		self:ScheduleRepeatingEvent("ThaurissanHealthCheck", self.CheckHealth, 0.25, self)
 	end
 end
 
@@ -96,6 +120,8 @@ function module:OnDisengage()
 	hasRuneOfDetonation = false
 	hasRuneOfPower = false
 	hasRuneOfCombustion = false
+	nextFloorWarn = 75
+	self:CancelScheduledEvent("ThaurissanHealthCheck")
 end
 
 function module:Event(msg)
@@ -104,42 +130,36 @@ function module:Event(msg)
 		self:Sync(syncName.runeDetonation)
 		if string.find(msg, L["trigger_you"]) then
 			hasRuneOfDetonation = true
-
-			self:Message(L["msg_detonation"], "Personal")
-			self:Sound("RunAway")
-			self:WarningSign(icon.runeDetonation, timer.runeDuration, false, L["warn_detonation"])
+			self:CheckRuneCombination()
 		end
+		return
 	elseif string.find(msg, L["trigger_runeOfDetonationFade"]) then
 		hasRuneOfDetonation = false
-		-- clear warning sign and bar
-		self:RemoveBar(L["bar_runeDetonation"])
-		self:RemoveWarningSign(icon.runeDetonation)
+		self:CheckRuneCombination()
+		return
 
-		-- Rune of Combustion
+	-- Rune of Combustion
 	elseif string.find(msg, L["trigger_combustion"]) then
 		self:Sync(syncName.runeCombustion)
 		if string.find(msg, L["trigger_you"]) then
 			hasRuneOfCombustion = true
-
-			self:Message(L["msg_combustion"], "Personal")
-			self:Sound("Beware")
-			self:WarningSign(icon.runeCombustion, timer.runeDuration, false, L["warn_combustion"])
+			self:CheckRuneCombination()
 		end
+		return
 	elseif string.find(msg, L["trigger_runeOfCombustionFade"]) then
 		hasRuneOfCombustion = false
-		-- Rune of Power (floor zone)
+		self:CheckRuneCombination()
+		return
+
+	-- Rune of Power (floor zone)
 	elseif string.find(msg, L["trigger_runeOfPowerYou"]) then
 		hasRuneOfPower = true
-		if hasRuneOfDetonation and self.db.profile.runeofdetonation then
-			self:Message(L["msg_detonation_in_zone"], "Personal")
-			self:Sound("RunAway")
-		end
+		self:CheckRuneCombination()
+		return
 	elseif string.find(msg, L["trigger_runeOfPowerFade"]) then
 		hasRuneOfPower = false
-		if hasRuneOfCombustion and self.db.profile.runeofcombustion then
-			self:Message(L["msg_combustion_out_of_zone"], "Personal")
-			self:Sound("Beware")
-		end
+		self:CheckRuneCombination()
+		return
 	end
 end
 
@@ -148,6 +168,34 @@ function module:BigWigs_RecvSync(sync, rest, nick)
 		self:DetonationCast()
 	elseif sync == syncName.runeCombustion then
 		self:CombustionCast()
+	end
+end
+
+function module:CheckRuneCombination()
+	--print("DEBUG: check with detonation "..tostring(hasRuneOfDetonation)..", combustion "..tostring(hasRuneOfCombustion)..", power "..tostring(hasRuneOfPower))
+
+	if hasRuneOfDetonation and self.db.profile.runeofdetonation then
+		if hasRuneOfPower then
+			self:Message(L["msg_detonation"], "Personal", nil, "RunAway")
+			self:WarningSign(icon.runeDetonation, timer.runeDuration, false, L["warn_detonation"])
+		else
+			self:Message(L["msg_detonationSolved"], "Positive", nil, "Long")
+			self:RemoveWarningSign(icon.runeDetonation)
+		end
+	else
+		self:RemoveWarningSign(icon.runeDetonation)
+	end
+
+	if hasRuneOfCombustion and self.db.profile.runeofcombustion then
+		if not hasRuneOfPower then
+			self:Message(L["msg_combustion"], "Personal", nil, "Beware")
+			self:WarningSign(icon.runeCombustion, timer.runeDuration, false, L["warn_combustion"])
+		else
+			self:Message(L["msg_combustionSolved"], "Positive", nil, "Long")
+			self:RemoveWarningSign(icon.runeCombustion)
+		end
+	else
+		self:RemoveWarningSign(icon.runeCombustion)
 	end
 end
 
@@ -173,184 +221,100 @@ function module:DetonationCast()
 	end
 end
 
+function module:CheckHealth()
+	if UnitExists(guid.thaurissan) and nextFloorWarn > 0 then
+		local percent = math.ceil(100*(UnitHealth(guid.thaurissan)/UnitHealthMax(guid.thaurissan)))
+		if percent <= (nextFloorWarn + floorWarn) then
+			if self.db.profile.floorwarn then
+				self:Message(string.format(L["msg_floorwarn"], nextFloorWarn), "Attention")
+			end
+			nextFloorWarn = nextFloorWarn - 25
+		end
+	else
+		self:CancelScheduledEvent("ThaurissanHealthCheck")
+	end
+end
+
 function module:Test()
 	-- Initialize module state
 	self:Engage()
 
 	local events = {
-		-- ==== Test Case 1: Detonation while OUTSIDE zone ====
-		{ time = 3, func = function()
-			print("=== Case 1: Detonation while OUTSIDE zone ===")
-		end },
-		{ time = 5, func = function()
-			local msg = "You are afflicted by Rune of Detonation."
-			print("Test: " .. msg)
-			print("Expected: Base detonation alert only")
-			module:TriggerEvent("CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE", msg)
-		end },
-		{ time = 8, func = function()
-			local msg = "Raider is afflicted by Rune of Detonation."
-			print("Test: " .. msg .. " (sync test)")
-			module:TriggerEvent("CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE", msg)
-		end },
-		{ time = 11, func = function()
-			local msg = "Rune of Detonation fades from you."
-			print("Test: " .. msg)
-			print("Expected: Alert clears")
-			module:TriggerEvent("CHAT_MSG_SPELL_AURA_GONE_SELF", msg)
-		end },
-
-		-- ==== Test Case 2: Detonation while INSIDE zone ====
-		{ time = 14, func = function()
-			print("=== Case 2: Detonation while INSIDE zone ===")
-		end },
-		{ time = 15, func = function()
+		-- Gaining Rune of Power (no alert expected)
+		{ time = 20, func = function()
 			local msg = "You are afflicted by Rune of Power."
 			print("Test: " .. msg)
-			print("Expected: No alert")
 			module:TriggerEvent("CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE", msg)
 		end },
-		{ time = 17, func = function()
+		-- Late first cast
+		-- Gaining Rune of Detonation while having Rune of Power (ALERT EXPECTED)
+		{ time = 22, func = function()
 			local msg = "You are afflicted by Rune of Detonation."
 			print("Test: " .. msg)
-			print("Expected: Base detonation alert + 'in zone' alert (2 alerts)")
 			module:TriggerEvent("CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE", msg)
-		end },
-		{ time = 20, func = function()
-			local msg = "Rune of Power fades from you."
-			print("Test: " .. msg)
-			print("Expected: No extra alert (now in correct state)")
-			module:TriggerEvent("CHAT_MSG_SPELL_AURA_GONE_SELF", msg)
 		end },
 		{ time = 22, func = function()
-			local msg = "Rune of Detonation fades from you."
+			local msg = "Raider is afflicted by Rune of Detonation."
 			print("Test: " .. msg)
-			print("Expected: Alert clears")
-			module:TriggerEvent("CHAT_MSG_SPELL_AURA_GONE_SELF", msg)
-		end },
-
-		-- ==== Test Case 3: Get Power while having Detonation ====
-		{ time = 25, func = function()
-			print("=== Case 3: Enter zone while having Detonation ===")
-		end },
-		{ time = 26, func = function()
-			local msg = "You are afflicted by Rune of Detonation."
-			print("Test: " .. msg)
-			print("Expected: Base detonation alert only")
-			module:TriggerEvent("CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE", msg)
-		end },
-		{ time = 28, func = function()
-			local msg = "You are afflicted by Rune of Power."
-			print("Test: " .. msg .. " (entering zone)")
-			print("Expected: 'In zone' alert")
-			module:TriggerEvent("CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE", msg)
-		end },
-		{ time = 31, func = function()
-			local msg = "Rune of Detonation fades from you."
-			print("Test: " .. msg)
-			module:TriggerEvent("CHAT_MSG_SPELL_AURA_GONE_SELF", msg)
-		end },
-		{ time = 32, func = function()
-			local msg = "Rune of Power fades from you."
-			print("Test: " .. msg)
-			module:TriggerEvent("CHAT_MSG_SPELL_AURA_GONE_SELF", msg)
-		end },
-
-		-- ==== Test Case 4: Combustion while OUTSIDE zone ====
-		{ time = 35, func = function()
-			print("=== Case 4: Combustion while OUTSIDE zone ===")
-		end },
-		{ time = 36, func = function()
-			local msg = "You are afflicted by Rune of Combustion."
-			print("Test: " .. msg)
-			print("Expected: Base combustion alert + 'out of zone' alert (2 alerts)")
-			module:TriggerEvent("CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE", msg)
-		end },
-		{ time = 39, func = function()
-			local msg = "Sorcerer-Thane Thaurissan's Rune of Combustion fails. Raider is immune."
-			print("Test: " .. msg .. " (sync test)")
 			module:TriggerEvent("CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE", msg)
 		end },
-		{ time = 42, func = function()
-			local msg = "Rune of Combustion fades from you."
+		-- Losing Rune of Power while keeping Rune of Detonation (alert icon should clear)
+		{ time = 24, func = function()
+			local msg = "Rune of Power fades from you."
 			print("Test: " .. msg)
-			print("Expected: State clears")
 			module:TriggerEvent("CHAT_MSG_SPELL_AURA_GONE_SELF", msg)
 		end },
-
-		-- ==== Test Case 5: Combustion while INSIDE zone ====
-		{ time = 45, func = function()
-			print("=== Case 5: Combustion while INSIDE zone ===")
-		end },
-		{ time = 46, func = function()
+		-- Regaining Rune of Power while having Rune of Detonation (ALERT EXPECTED)
+		{ time = 26, func = function()
 			local msg = "You are afflicted by Rune of Power."
 			print("Test: " .. msg)
-			print("Expected: No alert")
 			module:TriggerEvent("CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE", msg)
 		end },
-		{ time = 48, func = function()
-			local msg = "You are afflicted by Rune of Combustion."
-			print("Test: " .. msg)
-			print("Expected: Base combustion alert only (already in zone)")
-			module:TriggerEvent("CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE", msg)
-		end },
-		{ time = 51, func = function()
-			local msg = "Rune of Combustion fades from you."
+		-- Losing Rune of Detonation (alert icon should clear)
+		{ time = 28, func = function()
+			local msg = "Rune of Detonation fades from you."
 			print("Test: " .. msg)
 			module:TriggerEvent("CHAT_MSG_SPELL_AURA_GONE_SELF", msg)
 		end },
-		{ time = 52, func = function()
+		-- Clear Rune of Power for next test
+		{ time = 30, func = function()
 			local msg = "Rune of Power fades from you."
 			print("Test: " .. msg)
 			module:TriggerEvent("CHAT_MSG_SPELL_AURA_GONE_SELF", msg)
 		end },
 
-		-- ==== Test Case 6: Leave zone while having Combustion ====
-		{ time = 55, func = function()
-			print("=== Case 6: Leave zone while having Combustion ===")
+		-- Early second cast
+		{ time = 40, func = function()
+			local msg = "You are afflicted by Rune of Combustion."
+			print("Test: " .. msg)
+			module:TriggerEvent("CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE", msg)
 		end },
-		{ time = 56, func = function()
+		{ time = 40, func = function()
+			local msg = "Sorcerer-Thane Thaurissan's Rune of Combustion fails. Raider is immune."
+			print("Test: " .. msg)
+			module:TriggerEvent("CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE", msg)
+		end },
+		-- Walk into zone
+		{ time = 44, func = function()
 			local msg = "You are afflicted by Rune of Power."
 			print("Test: " .. msg)
 			module:TriggerEvent("CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE", msg)
 		end },
-		{ time = 57, func = function()
-			local msg = "You are afflicted by Rune of Combustion."
-			print("Test: " .. msg)
-			print("Expected: Base combustion alert only")
-			module:TriggerEvent("CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE", msg)
-		end },
-		{ time = 59, func = function()
-			local msg = "Rune of Power fades from you."
-			print("Test: " .. msg .. " (leaving zone)")
-			print("Expected: 'Out of zone' alert")
-			module:TriggerEvent("CHAT_MSG_SPELL_AURA_GONE_SELF", msg)
-		end },
-		{ time = 62, func = function()
-			local msg = "Rune of Combustion fades from you."
-			print("Test: " .. msg)
-			module:TriggerEvent("CHAT_MSG_SPELL_AURA_GONE_SELF", msg)
-		end },
 
-		-- ==== Test Case 7: Edge cases - resists and immunities ====
-		{ time = 65, func = function()
-			print("=== Case 7: Resists and immunities ===")
-		end },
-		{ time = 66, func = function()
+		-- Third cast
+		{ time = 60, func = function()
 			local msg = "Sorcerer-Thane Thaurissan's Rune of Detonation was resisted by you."
 			print("Test: " .. msg)
-			print("Expected: No personal alert (resisted)")
 			module:TriggerEvent("CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE", msg)
 		end },
-		{ time = 68, func = function()
+		{ time = 60, func = function()
 			local msg = "Raider is afflicted by Rune of Detonation."
-			print("Test: " .. msg .. " (another player)")
+			print("Test: " .. msg)
 			module:TriggerEvent("CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE", msg)
 		end },
 
 		-- End of Test
-		{ time = 70, func = function()
-			print("=== Test Complete ===")
+		{ time = 65, func = function()
 			print("Test: Disengage")
 			module:Disengage()
 		end },
@@ -361,8 +325,7 @@ function module:Test()
 		self:ScheduleEvent("ThaurissanTest" .. i, event.func, event.time)
 	end
 
-	self:Message("Thaurissan comprehensive test started - 7 test cases", "Positive")
-	print("Test will run for 70 seconds and cover all Event() logic paths")
+	self:Message("Thaurissan test started", "Positive")
 	return true
 end
 

--- a/Raids/Naxxramas/Horsemen.lua
+++ b/Raids/Naxxramas/Horsemen.lua
@@ -112,6 +112,8 @@ L:RegisterTranslations("enUS", function()
 		proximity_cmd = "proximity",
 		proximity_name = "Proximity Warning",
 		proximity_desc = "Show Proximity Warning Frame",
+
+		spellEffectWarning = "BigWigs: Your spellEffectLevel is set to 0, this makes void/pink zones impossible to see.  Consider changing this in your graphics options or typing /run SetCVar(\"spellEffectLevel\", 2).",
 	}
 end)
 
@@ -185,6 +187,12 @@ function module:OnEnable()
 	self:ThrottleSync(5, syncName.meteortimer)
 
 	self:UpdateBossStatusFrame()
+
+	-- check if spellEffectLevel is set to 0 and warn
+	if GetCVar("spellEffectLevel") == "0" then
+		self:Message(L["spellEffectWarning"], "Attention")
+		DEFAULT_CHAT_FRAME:AddMessage(L["spellEffectWarning"], 1, 1, 0)
+	end
 end
 
 function module:OnSetup()

--- a/Raids/Naxxramas/Kelthuzad.lua
+++ b/Raids/Naxxramas/Kelthuzad.lua
@@ -213,7 +213,7 @@ L:RegisterTranslations("enUS", function()
 		bar_bloodTapA = "Blood Tap +",
 		bar_bloodTapB = "% Damage",
 
-		spellEffectWarning = "BigWigs: Your spellEffectLevel is set to 0, this makes fissures extremely hard to see.  Consider changing this in your graphics options or typing /run SetCVar(\"spellEffectLevel\", 2)."
+		spellEffectWarning = "BigWigs: Your spellEffectLevel is set to 0, this makes void/pink zones impossible to see.  Consider changing this in your graphics options or typing /run SetCVar(\"spellEffectLevel\", 2)."
 	}
 end)
 
@@ -430,7 +430,7 @@ function module:OnEnable()
 	-- check if spellEffectLevel is set to 0 and warn
 	if GetCVar("spellEffectLevel") == "0" then
 		self:Message(L["spellEffectWarning"], "Attention")
-		DEFAULT_CHAT_FRAME:AddMessage(L["spellEffectWarning"])
+		DEFAULT_CHAT_FRAME:AddMessage(L["spellEffectWarning"], 1, 1, 0)
 	end
 end
 

--- a/Raids/ZG/Arlokk.lua
+++ b/Raids/ZG/Arlokk.lua
@@ -47,7 +47,7 @@ L:RegisterTranslations("enUS", function() return {
 	trigger_markOther = "(.+) is afflicted by Mark of Arlokk.", --CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE // CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE
 	trigger_markFade = "Mark of Arlokk fades from (.+).", --CHAT_MSG_SPELL_AURA_GONE_SELF // CHAT_MSG_SPELL_AURA_GONE_PARTY // CHAT_MSG_SPELL_AURA_GONE_OTHER
 	msg_mark = " is Marked!",
-	bar_mark = " Marked",
+	bar_mark = " Marked >target<",
 	
 	trigger_ww = "High Priestess Arlokk's Whirlwind",--CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_PARTY_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_SELF_DAMAGE
 	bar_ww = "Whirlwind CD",
@@ -332,8 +332,7 @@ end
 function module:Mark(rest)
 	self:Message(rest..L["msg_mark"], "Attention")
 
-	self:Bar(rest..L["bar_mark"].. " >Click Me<", timer.mark, icon.mark, true, color.mark)
-	self:SetCandyBarOnClick("BigWigsBar "..rest..L["bar_mark"].. " >Click Me<", function(name, button, extra) TargetByName(extra, true) end, rest)
+	self:ClickBar(rest..L["bar_mark"], timer.mark, icon.mark, rest, false, true, color.mark)
 
 	if (IsRaidLeader() or IsRaidOfficer()) then
 		for i=1,GetNumRaidMembers() do
@@ -345,7 +344,7 @@ function module:Mark(rest)
 end
 
 function module:MarkFade(rest)
-	self:RemoveBar(rest..L["bar_mark"].. " >Click Me<")
+	self:RemoveBar(rest..L["bar_mark"])
 	
 	if (IsRaidLeader() or IsRaidOfficer()) then
 		for i=1,GetNumRaidMembers() do

--- a/Raids/ZG/Hakkar.lua
+++ b/Raids/ZG/Hakkar.lua
@@ -59,8 +59,10 @@ L:RegisterTranslations("enUS", function()
 		trigger_causeInsanityOther = "(.+) is afflicted by Cause Insanity.", --CHAT_MSG_SPELL_PERIODIC_HOSTILEPLAYER_DAMAGE // CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE // CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE
 		trigger_causeInsanityFade = "Cause Insanity fades from (.+).", --CHAT_MSG_SPELL_AURA_GONE_SELF // CHAT_MSG_SPELL_AURA_GONE_PARTY // CHAT_MSG_SPELL_AURA_GONE_OTHER
 		trigger_causeInsanityTotem = "Hakkar's Cause Insanity fails. Grounding Totem is immune.", --CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE // CHAT_MSG_SPELL_CREATURE_VS_PARTY_DAMAGE
-		msg_causeInsanity = " MC",
-		bar_causeInsanity = " MC",
+		msg_causeInsanity = " Mind-Controlled!",
+		bar_causeInsanity = (playerClass=="MAGE" and " MC >sheep<") or (playerClass=="WARLOCK" and " MC >fear<") or " MC >target<",
+		spell_causeInsanity = (playerClass=="MAGE" and "Polymorph") or (playerClass=="WARLOCK" and "Fear") or false,
+		bar_causeInsanityGrounded = "MC Grounded",
 		bar_causeInsanityCd = "MC CD",
 
 		trigger_bloodSiphon = "Hakkar gains Blood Siphon.", --CHAT_MSG_SPELL_PERIODIC_CREATURE_BUFFS
@@ -437,22 +439,13 @@ function module:CauseInsanity(rest)
 	self:RemoveBar(L["bar_causeInsanityCd"])
 
 	if rest == "Grounded!" then
-		self:Bar("Grounded -" .. L["bar_causeInsanity"], timer.causeInsanityDur, icon.causeInsanity, true, color.causeInsanityDur)
+		self:Bar(L["bar_causeInsanityGrounded"], timer.causeInsanityDur, icon.causeInsanity, true, color.causeInsanityDur)
 		self:DelayedBar(timer.causeInsanityDur, L["bar_causeInsanityCd"], timer.causeInsanityCd, icon.causeInsanity, true, color.causeInsanityCd)
 	else
-		self:Bar(rest .. L["bar_causeInsanity"] .. " >Click Me<", timer.causeInsanityDur, icon.causeInsanity, true, color.causeInsanityDur)
-		self:SetCandyBarOnClick("BigWigsBar " .. rest .. L["bar_causeInsanity"] .. " >Click Me<", function(name, button, extra)
-			TargetByName(extra, true)
-			if playerClass == "MAGE" then
-				CastSpellByName("Polymorph")
-			elseif playerClass == "WARLOCK" then
-				CastSpellByName("Fear")
-			end
-		end, rest)
-
+		self:ClickBar(rest .. L["bar_causeInsanity"], timer.causeInsanityDur, icon.causeInsanity, rest, L["spell_causeInsanity"], true, color.causeInsanityDur)
+		
 		if playerClass == "MAGE" or playerClass == "WARLOCK" then
-			self:Message(rest .. L["msg_causeInsanity"], "Attention", false, nil, false)
-			self:Sound("Info")
+			self:Message(rest .. L["msg_causeInsanity"], "Attention", false, "Info", false)
 			self:WarningSign(icon.causeInsanity, 0.7)
 		end
 
@@ -467,7 +460,7 @@ function module:CauseInsanity(rest)
 end
 
 function module:CauseInsanityFade(rest)
-	self:RemoveBar(rest .. L["bar_causeInsanity"] .. " >Click Me<")
+	self:RemoveBar(rest .. L["bar_causeInsanity"])
 
 	if (IsRaidLeader() or IsRaidOfficer()) then
 		for i = 1, GetNumRaidMembers() do

--- a/Raids/ZG/Mandokir.lua
+++ b/Raids/ZG/Mandokir.lua
@@ -331,8 +331,9 @@ end
 
 function module:Sunder(rest)
 	local sunderPlayer = strsub(rest,0,strfind(rest," ") - 1)
-	local sunderQty = tonumber(strsub(rest,strfind(rest," "),strlen(rest)))
-	
+	local sunderQty = tonumber(strsub(rest,strfind(rest," ") + 1,strlen(rest)))
+	if not sunderQty then return end
+
 	self:RemoveBar(sunderPlayer.." ".."1"..L["bar_sunder"])
 	self:RemoveBar(sunderPlayer.." ".."2"..L["bar_sunder"])
 	self:RemoveBar(sunderPlayer.." ".."3"..L["bar_sunder"])

--- a/documentation/API.txt
+++ b/documentation/API.txt
@@ -1,0 +1,78 @@
+
+-------------------
+modulePrototype API
+-------------------
+
+module:OnSetup()
+module:OnEngage()
+module:OnDisengage()
+
+module:Sync(sync)
+module:DelayedSync(delay, sync)
+module:CancelDelayedSync(sync)
+module:ThrottleSync(throttle, sync)
+
+module:Message(text, priority, noRaidSay, sound, broadcastOnly)
+module:DelayedMessage(delay, text, priority, noRaidSay, sound, broadcastOnly)
+module:CancelDelayedMessage(text)
+
+module:Bar(text, time, icon, otherColor, c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, emphasize, target, spell)
+module:RemoveBar(text)
+module:DelayedBar(delay, text, time, icon, otherColor, c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, emphasize, target, spell)
+module:CancelDelayedBar(text)
+
+module:IntervalBar(text, intervalMin, intervalMax, icon, otherColor, c1, c2, c3, c4, c5, c6, c7, c8, c9, c10)
+module:DelayedIntervalBar(delay, text, intervalMin, intervalMax, icon, otherColor, c1, c2, c3, c4, c5, c6, c7, c8, c9, c10)
+
+module:ClickBar(text, time, icon, target, spell, otherColor, c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, emphasize)
+module:DelayedClickBar(delay, text, time, icon, target, spell, otherColor, c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, emphasize)
+
+module:MonitorBar(barName, icon, guid, type, displayText, insertMark, emphazise, otherColor, c1, c2, c3, c4, c5, c6, c7, c8, c9, c10)
+module:DelayedMonitorBar(delay, barName, icon, guid, type, displayText, insertMark, emphazise, otherColor, c1, c2, c3, c4, c5, c6, c7, c8, c9, c10)
+
+registered, time, elapsed, running = module:BarStatus(text)
+
+module:Sound(sound)
+module:DelayedSound(delay, sound, id)
+module:CancelDelayedSound(sound, id)
+
+module:Icon(name, iconnumber)
+module:RemoveIcon()
+
+module:WarningSign(icon, duration, force, text)
+module:RemoveWarningSign(icon, forceHide)
+module:DelayedWarningSign(delay, icon, duration, id)
+module:CancelDelayedWarningSign(icon, id)
+
+module:Say(msg)
+
+module:Proximity()
+module:RemoveProximity()
+
+module:SetRaidTargetForPlayer(player, mark) -- mark can be index or name
+module:GetAvailableRaidMark(excludeMarks, reverse)
+module:RestorePreviousRaidTargetForPlayer(player)
+module:RestoreInitialRaidTargetForPlayer(player)
+
+module:OnEnemyDeath(msg) -- do not register CHAT_MSG_COMBAT_HOSTILE_DEATH
+module:OnFriendlyDeath(msg) -- do not register CHAT_MSG_COMBAT_FRIENDLY_DEATH
+
+module:SendBossDeathSync()
+
+
+----------------
+Helper Functions
+----------------
+
+BigWigs:CancelAuraId(spellId) -- requires SuperWoW
+BigWigs:CancelAuraTexture(texture)
+BigWigs:BuffNameByIndex(buffIndex) -- returns localized name from tooltip
+
+-- depth (integer) specifies which units to scan (0 = raidN, 1 = raidNtarget, 2 = raidNtargettarget, etc). 
+BigWigs:GetUnitIdByName(name, depth) -- returns "raidN", "raidNtarget", etc
+BigWigs:GetTargetByName(name, depth) -- returns "targetName" of named unit
+BigWigs:GetGUIDByName(name, depth, ignoredGUIDs) -- ignoredGUIDs must be a table
+
+BigWigs:OffsetGUID(input, offset) -- adds offset (signed integer) to GUID string
+
+BigWigs:RaidTargetLookup(input) -- For string input (eg "star", "Circle", "none") returns raid target index for use with SetRaidTarget(unit, index). For integer input (eg 1, 8, nil) returns raid target name to translate the output of GetRaidTargetIndex(unit).

--- a/documentation/changelog.txt
+++ b/documentation/changelog.txt
@@ -1,0 +1,82 @@
+--------------------------------------
+Changelog for BigWigs - Golden Edition
+--------------------------------------
+
+February Update - 2026-03-01 (Golden 30135)
+---------------
+(MC) Thaurissan - correct positioning is now recognized, added warning about upcoming floor zones recasts
+(AQ40) C'Thun - new bars to monitor Stomach Tentacle HP
+(K40) Sanv - Curse and Rift Feedback handling (major contributions by DCV-2142), better HP checks
+(K40) Mephistroth - added Shackles CD & Fear CD (major contributions by DCV-2142), better Doom bar
+(K40) Rupturan - added Throw Boulder mechanic, added P1 boss kill Window of Opportunity, added warning when Felheart reaches >80% mana, added Felheart mana bar; also added Ignite Earth timers (with contributions by DCV-2142).
+(K40) Incantagos - click Affinity bars to target, better HP checks; also add summon CD (with contributions by DCV-2142).
+(K40) Chess - fixed triggers for King's Fury, Shadow Bolt Volley, etc.
+(K40)/(ZG)/(DM)/(Common Auras) - update to use new ClickBar style
+
+(Bars) added ClickBar and MonitorBar, added emphasis toggle to StartBar (all HP bars will now stay grouped up and never get emphasized)
+(Core) added several helper functions: BigWigs:GetUnitIdByName(name, depth), BigWigs:GetTargetByName(name, depth), BigWigs:GetGUIDByName(name, depth, ignoredGUIDs), BigWigs:OffsetGUID(input, offset), BigWigs:RaidTargetLookup(input)
+(Core) SetRaidTargetForPlayer(player, mark) now also takes string-type mark names instead of only indices
+(documentation) added updated API documentation, added changelog (this file)
+
+(K40)/(Naxx) - warning about low spellEffectLevel (by pepopo978)
+(ZG) Mandokir - hackfix for rare concat error (by pepopo978)
+(Spell Requests) - added Power Word: Shield (by pepopo978)
+
+
+Hotfix - 2026-02-10
+------
+(K40) Rupturan - fixed Ignite Rock sync
+
+
+January Update - 2026-01-21 (Golden 30134)
+--------------
+(MC) Twin Golems - fix death sync trigger
+(ZG) Hakkar - improved OnClick for MC bar
+(AQ20) Rajaxx - fixed death sync, improved Andorov handling
+(DM) Eye of Kilrogg - module added
+(K40) all modules are now in a separate menu from K10
+(Bars) announcing bars to /raid requires a Shift-click
+
+(K40) Gnarlmoon - improved ravens bar (by pepopo978)
+(K40) Chess - rook shield bash added (by pepopo978)
+(Mage Tools) - update (by pepopo978)
+
+
+Forking Update - December 2025 (Golden 30132)
+--------------
+(K40) Mephistroth - Waking Nightmare added
+(K40) various small fixes to Incantagos, Echo
+(MC) Ragnaros - major rework
+(Version Check) added support for independent forks
+(TOC) spun off Golden Edition as an independent fork
+
+
+K40 Round 2 - November 2025
+-----------
+(K40) various small fixes
+(K40) Incantagos - added Surge of Mana bars
+(K40) Rupturan - added features
+(K40) Mephistroth - added features
+
+
+Small Fixes - November 2025
+-----------
+(ZG) Venoxis - removed unused Venom Spit message
+(DM) Kromcrush - various fixes and clarifications
+(AQ40) C'Thun - fix map not retaining vertical position
+
+
+MC Update - September 2025
+---------
+(MC) Gehennas - removed
+(MC) Twin Golems - module added
+(MC) Thaurissan - module added
+(MC) Ragnaros - preliminary 1.18 changes
+
+
+K40 Round 1 - August 2025
+-----------
+(Core) Added BigWigs:BuffNameByIndex(buffIndex)
+(K40) Substantial changes to most K40 modules: KeeperGnarlmoon, Incantagos, Anomalus, EchoOfMedivh, ChessFight, SanvTasdal, KaraTrash
+(Libs) Updated Babble-Zone and Babble-Boss with TWoW custom names
+(MC) 1.18 updates for Ragnaros


### PR DESCRIPTION
February Update 2026
* new MonitorBars for real-time monitoring of HP or Mana of a unit (for now used only on C'Thun and Rupturan)
* big update to Rupturan - show current Boulder target and mark it with Moon, announce Boulder misses (no add), Window of Opportunity bar to safely kill Rupturan in P1, alert at high Felheart mana, Felheart mana bar on screen, optional Ignite Earth timer
* Sanv warns for the last Curse before a Rift Feedback, optional CD bars for Curse and Feedback
* click timer bar to target Affinities at Incantagos, optional summon CD bar
* fixes for Chess (broken Hide alert)
* Meph has a bar for minimum Shackle CD now
* reworked Thaurissan module with better information
* huge improvements to bar OnClick handling, and lots of other cool tech under the hood
* new changelog
* recent pepopo update (SpellRequest, new warnings about low spellEffectLevel to see floor zones)