### PR TITLE
March Update 2026

### DIFF
--- a/BigWigs.toc
+++ b/BigWigs.toc
@@ -1,8 +1,8 @@
 ## Interface: 11200
 
-## X-Revision: 30135
+## X-Revision: 30136
 ## X-Fork: Pepo
-## Title: |cFFFF8080Pepopo|r Big Wigs |cff7fff7f30135|r |cffabd473Turtle-WoW|r
+## Title: |cFFFF8080Pepopo|r Big Wigs |cff7fff7f30136|r |cffabd473Turtle-WoW|r
 ## Title-zhCN: |cffabd473Turtle-WoW|r Big Wigs
 ## Notes: Boss Mods with Timer bars.
 ## Notes-esES: Módulos para Jefes con barras temporizadoras.

--- a/Core.lua
+++ b/Core.lua
@@ -176,7 +176,7 @@ L:RegisterTranslations("esES", function()
 		["Moon"] = "Luna",
 		["Square"] = "Cuadrado",
 		["Cross"] = "Cruz",
-		["Skull"] = "Cráneo",
+		["Skull"] = "Calavera",
 		["none"] = "ninguna",
 		["unmarked"] = "sin marcar",
 	}
@@ -237,12 +237,12 @@ L:RegisterTranslations("deDE", function()
 		-- Raid Marks
 		["Star"] = "Stern",
 		["Circle"] = "Kreis",
-		["Diamond"] = "Raute",
+		["Diamond"] = "Diamant",
 		["Triangle"] = "Dreieck",
 		["Moon"] = "Mond",
 		["Square"] = "Quadrat",
 		["Cross"] = "Kreuz",
-		["Skull"] = "Schädel",
+		["Skull"] = "Totenkopf",
 		["none"] = "keine",
 		["unmarked"] = "unmarkiert",
 	}
@@ -1638,8 +1638,7 @@ function BigWigs:GetTargetByName(name, depth)
 	depth = depth or 1 -- default to targets of raid members
 	local unitId = BigWigs:GetUnitIdByName(name, depth)
 	if unitId then 
-		local target = UnitName(unitId.."target")
-		return target
+		return UnitName(unitId.."target")
 	end
 end
 
@@ -1688,7 +1687,7 @@ function BigWigs:OffsetGUID(input, offset)
 	return prefix..string.format("%08X",highOutput)..string.format("%08X",lowOutput)
 end
 
-function BigWigs:RaidTargetLookup(input)
+function BigWigs:RaidTargetLookup(input, colorize)
 	local raidTargets = {
 		[0] = "none", -- following pattern of SetRaidTarget()
 		[1] = "Star",
@@ -1704,7 +1703,13 @@ function BigWigs:RaidTargetLookup(input)
 	-- convert index to name
 	if type(input) == "number" then
 		local output = raidTargets[input]
-		if output then return L[output] end --localize output for displaying
+		if output then --localize output for displaying
+			if colorize then
+				return BigWigsColors:ColorizeString(L[output], output)
+			else
+				return L[output]
+			end
+		end
 
 	-- convert name to index
 	elseif type(input) == "string" then
@@ -1717,7 +1722,96 @@ function BigWigs:RaidTargetLookup(input)
 
 	-- nil means unmarked following pattern of GetRaidTargetIndex()
 	elseif type(input) == "nil" then
-		return L["unmarked"]
+		if colorize then
+			return BigWigsColors:ColorizeString(L["unmarked"], "unmarked")
+		else
+			return L["unmarked"]
+		end
+	end
+end
+
+function BigWigs:FormatLargeNumber(integer)
+	local integerString = tostring(integer)
+	local length = string.len(integerString)
+		
+	-- following the design of the default UI we want to return no more than 4 significant digits
+	if length < 5 then return integerString end
+	
+	-- the 1.12 client uses signed 32 bit integers for values like health, so we don't need to worry about anything above 2 billion
+	local suffix = "k"
+	if length > 7 then
+		suffix = "m"
+		length = length - 3
+	end
+
+	if length == 5 then
+		return string.sub(integerString,1,2).."."..string.sub(integerString,3,4)..suffix
+	elseif length == 6 then
+		return string.sub(integerString,1,3).."."..string.sub(integerString,4,4)..suffix
+	elseif length == 7 then
+		return string.sub(integerString,1,4)..suffix
+	end
+end
+
+function BigWigs:BuffIsPresent(unitId, spellId)
+	if UnitExists(unitId) then
+		local i = 1
+		while UnitBuff(unitId, i) do
+			local _,_,foundId = UnitBuff(unitId, i)
+			if foundId == spellId then
+				return true
+			end
+			i = i + 1
+		end
+	end
+end
+
+function BigWigs:DebuffIsPresent(unitId, spellId)
+	if UnitExists(unitId) then
+		local i = 1
+		while UnitDebuff(unitId, i) do
+			local _,_,_,foundId = UnitDebuff(unitId, i)
+			if foundId == spellId then
+				return true
+			end
+			i = i + 1
+		end
+	end
+end
+
+function BigWigs:AuraIsPresent(unitId, spellId)
+	return BigWigs:DebuffIsPresent(unitId, spellId) or BigWigs:BuffIsPresent(unitId, spellId)
+end
+
+function BigWigs:GetCastTimeCoefficient(unitId)
+	local debuffs = { -- {spellId, multiplier, skip next if found}
+		[1] = {11719, 1.6, 1}, -- Curse of Tongues Rank 2
+		[2] = {1714, 1.5, 0}, -- Curse of Tongues Rank 1
+		[3] = {11398, 1.6, 2}, -- Mind-numbing Poison III
+		[4] = {8692, 1.5, 1}, -- Mind-numbing Poison II
+		[5] = {5760, 1.4, 0}, -- Mind-numbing Poison I
+	}
+	local coefficient = 1
+	
+	if UnitExists(unitId) then
+		for i=1,table.getn(debuffs) do
+			if BigWigs:AuraIsPresent(unitId, debuffs[i][1]) then
+				coefficient = coefficient * debuffs[i][2]
+				i = i + debuffs[i][3] -- skip checking lower ranks
+			end
+		end
+	end
+	
+	return coefficient
+end
+
+function BigWigs:GetHealthPercent(unitId, round)
+	if UnitExists(unitId) then
+		if round then
+			return math.floor(UnitHealth(unitId)/UnitHealthMax(unitId) * 100)
+		else
+			return UnitHealth(unitId)/UnitHealthMax(unitId) * 100
+		end
 	end
 end
 

--- a/Libs/Babble-Boss-2.2/Babble-Boss-2.2.lua
+++ b/Libs/Babble-Boss-2.2/Babble-Boss-2.2.lua
@@ -28,6 +28,25 @@ local BabbleBoss = AceLibrary("AceLocale-2.2"):new(MAJOR_VERSION)
 
 BabbleBoss:RegisterTranslations("enUS", function()
 	return {
+		["Ezzel Darkbrewer"] = true, --BWL extension
+		["Broodcommander Axelus"] = true, --Onyxia extension
+		["Smoldaris"] = true, --MC extension
+		["Basalthar"] = true,
+		["Sorcerer-Thane Thaurissan"] = true,
+		["Keeper Gnarlmoon"] = true, --Tower of Karazhan
+		["Ley-Watcher Incantagos"] = true,
+		["Anomalus"] = true,
+		["Echo of Medivh"] = true,
+		["Rook"] = true,
+		["Bishop"] = true,
+		["Knight"] = true,
+		["Queen"] = true,
+		["King"] = true,
+		["Sanv Tas'dal"] = true,
+		["Rupturan the Broken"] = true,
+		["Fragment of Rupturan"] = true,
+		["Kruul"] = true,
+		["Mephistroth"] = true,
 		["Rotmaw"] = true, --Black Morass
 		["Antnormi"] = true,
 		["Mossheart"] = true,

--- a/Libs/Babble-Zone-2.2/Babble-Zone-2.2.lua
+++ b/Libs/Babble-Zone-2.2/Babble-Zone-2.2.lua
@@ -36,9 +36,11 @@ BabbleZone:RegisterTranslations("enUS", function()
 		["Balor"] = true,
 		["Blackrock Spire"] = true,
 		["Blackstone Island"] = true,
+		["Blood Ring"] = true, --arena
 		["Dragonmaw Retreat"] = true,
 		["Crescent Grove"] = true,
 		["Emerald Sanctum"] = true,
+		["Frostmane Hollow"] = true, --1.18.1
 		["Gillijim's Isle"] = true,
 		["Gilneas City"] = true,
 		["Gilneas"] = true,
@@ -51,7 +53,9 @@ BabbleZone:RegisterTranslations("enUS", function()
 		["Lapidis Isle"] = true,
 		["Lower Karazhan Halls"] = true,
 		["Moomoo Grove"] = true,
+		["Moonwhisper Coast"] = true, --1.18.1
 		["Northwind"] = true,
+		["Ruins of Lordaeron"] = true, --arena
 		["Scarlet Monastery Armory"] = true,
 		["Scarlet Monastery Cathedral"] = true,
 		["Scarlet Monastery Graveyard"] = true,
@@ -62,12 +66,16 @@ BabbleZone:RegisterTranslations("enUS", function()
 		["Stormwrought Descent"] = true,
 		["Stormwrought Ruins"] = true,
 		["Sunnyglade Valley"] = true,
+		["Sunstrider Court"] = true, --arena
 		["Tel'Abim"] = true,
 		["Thalassian Highlands"] = true,
 		["The Black Morass"] = true,
 		["The Rock of Desolation"] = true,
 		["The Upper Necropolis"] = true,
+		["Thorn Gorge"] = true, --1.18.1 battleground
+		["Timbermaw Hold"] = true, --1.18.1
 		["Tower of Karazhan"] = true,
+		["Windhorn Canyon"] = true, --1.18.1
 		["Winter Veil Vale"] = true,
 		["???"] = true, --1.17 name for The Rock of Desolation
 		

--- a/Plugins/Bars.lua
+++ b/Plugins/Bars.lua
@@ -851,7 +851,7 @@ function BigWigsBars:BigWigs_StartIntervalBar(module, text, intervalMin, interva
 	end
 end
 
-local monitorBarCache = {-- [i] = {barName, GUID, type, barText, insertMark}
+local monitorBarCache = {-- [i] = {id, GUID, type, barText, insertMark}
 }
 function BigWigsBars:BigWigs_StartMonitorBar(module, barName, icon, guid, type, displayText, insertMark, emphazise, otherc, c1, c2, c3, c4, c5, c6, c7, c8, c9, c10)
 	if (not barName) or (not guid) then
@@ -860,7 +860,7 @@ function BigWigsBars:BigWigs_StartMonitorBar(module, barName, icon, guid, type, 
 	
 	-- set up defaults
 	type = type or "health"
-	displayText = displayText or ""
+	displayText = displayText or barName
 	if emphazise == nil then
 		emphazise = false
 	end
@@ -877,10 +877,14 @@ function BigWigsBars:BigWigs_StartMonitorBar(module, barName, icon, guid, type, 
 		return string.format("%d%%", floor(t))
 	end)
 
+	-- set the bar's background color to a darker hue
+	local _, r, g, b = paint:GetRGBPercent(c1)
+	module:SetCandyBarBackgroundColorRGB(id, r*0.7, g*0.7, b*0.7, 0.5)
 
+	-- enter/update bar's cache entry
 	local barExists = false
 	for i = 1, table.getn(monitorBarCache) do
-		if monitorBarCache[i] and monitorBarCache[i][1] == barName then
+		if monitorBarCache[i] and monitorBarCache[i][1] == id then
 			barExists = true
 			monitorBarCache[i][2] = guid
 			monitorBarCache[i][3] = type
@@ -889,7 +893,7 @@ function BigWigsBars:BigWigs_StartMonitorBar(module, barName, icon, guid, type, 
 		end
 	end
 	if not barExists then
-		table.insert(monitorBarCache, { barName, guid, type, displayText, insertMark })
+		table.insert(monitorBarCache, { id, guid, type, displayText, insertMark })
 	end
 
 	BigWigsBars:UpdateAllMonitorBars()
@@ -901,8 +905,7 @@ function BigWigsBars:UpdateAllMonitorBars()
 	end
 
 	for i = 1,table.getn(monitorBarCache) do
-		local id = "BigWigsBar " .. monitorBarCache[i][1]
-		local bar = candybar.var.handlers[id]
+		local bar = candybar.var.handlers[monitorBarCache[i][1]]
 		if not bar then
 			table.remove(monitorBarCache, i)
 			self:UpdateAllMonitorBars()
@@ -915,21 +918,21 @@ function BigWigsBars:UpdateAllMonitorBars()
 		local currentPercent = 0
 		if monitorBarCache[i][3] == "health" and UnitExists(monitorBarCache[i][2]) then
 			currentValue = UnitHealth(monitorBarCache[i][2])
-			currentValueString = currentValue.." "..L["HP"]
+			currentValueString = BigWigs:FormatLargeNumber(currentValue).." "..L["HP"]
 			currentPercent = math.floor(currentValue/UnitHealthMax(monitorBarCache[i][2]) * 100)
 		elseif monitorBarCache[i][3] == "mana" and UnitExists(monitorBarCache[i][2]) then
 			currentValue = UnitMana(monitorBarCache[i][2])
-			currentValueString = currentValue.." "..L["Mana"]
+			currentValueString = BigWigs:FormatLargeNumber(currentValue).." "..L["Mana"]
 			currentPercent = math.floor(currentValue/UnitManaMax(monitorBarCache[i][2]) * 100)
 		end
 		-- update bar
 		bar.elapsed = 100 - currentPercent
-		candybar:Update(id)
+		candybar:Update(monitorBarCache[i][1])
 
 		-- piece together new bar text
 		local assembledText = monitorBarCache[i][4]
 		if monitorBarCache[i][5] == true and UnitExists(monitorBarCache[i][2]) then
-			assembledText = assembledText.." "..BigWigs:RaidTargetLookup(GetRaidTargetIndex(monitorBarCache[i][2]))
+			assembledText = assembledText.." "..BigWigs:RaidTargetLookup(GetRaidTargetIndex(monitorBarCache[i][2]), true)
 		end
 		if UnitExists(monitorBarCache[i][2]) and not UnitIsDead(monitorBarCache[i][2]) then
 			assembledText = assembledText.." - "..currentValueString
@@ -937,7 +940,7 @@ function BigWigsBars:UpdateAllMonitorBars()
 			assembledText = assembledText.." - "..L["dead"]
 		end
 		-- update bar
-		candybar:SetText(id, assembledText)
+		candybar:SetText(monitorBarCache[i][1], assembledText)
 	end
 
 	-- check again in quarter of a second; non-repeatable so it auto-cancels if bar cache is empty

--- a/Plugins/Colors.lua
+++ b/Plugins/Colors.lua
@@ -545,8 +545,26 @@ BigWigsColors.consoleOptions = {
 --      Initialization      --
 ------------------------------
 
+local function RegisterRaidTargetColors()
+	local raidTargetColors = {
+		unmarked = "bababa",
+		Star = "ffff00",
+		Circle = "ffa500",
+		Diamond = "ff20ff",
+		Triangle = "00ff00",
+		Moon = "e0ffff",
+		Square = "00baff",
+		Cross = "ff2020",
+		Skull = "ffffff"
+	}
+	for k,v in pairs(raidTargetColors) do
+		PaintChips:RegisterColor(k, v)
+	end
+end
+
 function BigWigsColors:OnRegister()
 	self:RegHex(self.db.profile)
+	RegisterRaidTargetColors()
 end
 
 function BigWigsColors:ResetDB()
@@ -625,5 +643,14 @@ function BigWigsColors:BarColor(time)
 	elseif n == 3 then return d[1], d[2], d[3]
 	elseif n == 2 then return d[1], d[2]
 	elseif n == 1 then return d[1] end
+end
+
+function BigWigsColors:ColorizeString(input, color)
+	if not color then color = input end
+	local hex = PaintChips:GetHex(color)
+	if hex then
+		input = "|cff"..hex..input.."|r"
+	end
+	return input
 end
 

--- a/Plugins/CommonAuras.lua
+++ b/Plugins/CommonAuras.lua
@@ -148,7 +148,7 @@ BigWigsCommonAuras.defaultDB = {
 	autofocus = false
 }
 BigWigsCommonAuras.consoleCmd = L["commonauras"]
-BigWigsCommonAuras.revision = 30065
+BigWigsCommonAuras.revision = 30066
 BigWigsCommonAuras.external = true
 BigWigsCommonAuras.consoleOptions = {
 	type = "group",
@@ -505,10 +505,10 @@ function BigWigsCommonAuras:UNIT_CASTEVENT(caster,target,action,spell_id,cast_ti
 	-- this technically false-postives on cast completions but it shouldn't matter for our purpose
 	local name,rank = SpellInfo(spell_id)
 	local fullname = rank == "" and name or format("%s(%s)",name,rank)
-	self:SpellStatusV2_SpellCastInstant(spell_id, name, rank, fullname, cast_time, target and UnitName(target))
+	self:SpellStatusV2_SpellCastInstant(spell_id, name, rank, fullname, cast_time, nil, nil, nil, target and UnitName(target))
 end
 
-function BigWigsCommonAuras:SpellStatusV2_SpellCastInstant(sId, sName, sRank, sFullName, sCastTime, target)
+function BigWigsCommonAuras:SpellStatusV2_SpellCastInstant(sId, sName, sRank, sFullName, sCastTime, sStopTime, sDuration, sDelay, target)
 	local targetName = target
 	if sName == BS["Fear Ward"] then
 		if not targetName then

--- a/Plugins/CommonAuras.lua
+++ b/Plugins/CommonAuras.lua
@@ -777,6 +777,7 @@ function BigWigsCommonAuras:BigWigs_RecvSync(sync, rest, nick)
 			self:PFUIFocus(rest)
 		end
 	elseif self.db.profile.fearward and sync == "BWCAFW" and rest then
+		if tonumber(rest) then rest = "?" end -- cosmetic fix for timestamp sync
 		self:TriggerEvent("BigWigs_Message", nick .. L["msg_fearward"] .. rest, "Positive", false, nil, false)
 		self:TriggerEvent("BigWigs_StartBar", self, nick .. L["bar_fearward"], timer.fearward, icon.fearward, true, color.fearward)
 	elseif self.db.profile.shieldwall and sync == "BWCASW" then
@@ -810,6 +811,7 @@ function BigWigsCommonAuras:BigWigs_RecvSync(sync, rest, nick)
 
 	elseif self.db.profile.spiritlink and sync == "BWCASL" and rest then
 		-- self:TriggerEvent("BigWigs_Message", L["msg_spiritLink"] .. rest, "Important", false, nil, false) -- noise
+		if tonumber(rest) then rest = nick end -- cosmetic fix for timestamp sync
 		self:TriggerEvent("BigWigs_Sound", "Info")
 		self:TriggerEvent("BigWigs_StartBar", self, rest .. L["bar_spiritLink"], timer.spiritLink, icon.spiritLink, true, color.spiritLink, nil, nil, nil, nil, nil, nil, nil, nil, nil, true, nick, false)
 

--- a/Plugins/Sound.lua
+++ b/Plugins/Sound.lua
@@ -67,6 +67,7 @@ local sounds = {
 	DispelPoison = "Interface\\AddOns\\BigWigs\\Sounds\\DispelPoison.mp3",
 
 	GoBow = "Interface\\AddOns\\BigWigs\\Sounds\\GoBow.mp3",
+	Hide = "Interface\\AddOns\\BigWigs\\Sounds\\hide.mp3",
 
 	Dance = "Interface\\AddOns\\BigWigs\\Sounds\\Dance.mp3",
 	FunDance = "Interface\\AddOns\\BigWigs\\Sounds\\FunDance.mp3",

--- a/README.md
+++ b/README.md
@@ -4,32 +4,30 @@ Big updates to K40 and MC (**check your boss settings!**), small fixes and updat
 Updates are summarized in the [changelog](https://github.com/ElesionWoW/BigWigs/blob/master/documentation/changelog.txt). Details are in individual commits.
 ## Karazhan 40 - Highlights
 * Trash - many additional mobs and mechanics (including "don't move" and "don't cast")
-* Keeper - accurate Owl phase timer
+* Keeper - accurate Owl phase timer, identification of Owl health by location
 * Incantagos - target Affinities automatically or by clicking on the timer bar, Surge of Mana victim bars, Blizzard warning
 * Anomalus - Floor Zone warnings
 * Echo - additional warnings, optional timers to align Resto Pot usage
-* Chess - accurate cast bars (hide, SBV), Curse CD (to allign hide phases)
+* Chess - accurate cast bars (hide, SBV), Curse CD (to allign hide phases), MC announcements, hide pre-warning (HP based)
 * Sanv - bar for add phase duration, warn about last Curse before Feedback
-* Rupturan - Boulder target warnings, P1 kill window, alert when you stand in fire, monitoring of Felheart mana
+* Rupturan - Boulder target warnings, P1 kill window, alert when you stand in fire, monitoring of Felheart mana, Fragment health bars
 * Mephistroth - Doom bar, purge alert, better Shards handling, sound cue on Shackle fade
 ## Other Feature Highlights
 * Announcing bars to /raid now requires a Shift-click to prevent accidental spam.
-* AQ40 - C'Thun map fix, vastly improved monitoring of Stomach Tentacles
+* AQ40 - C'Thun map fix, vastly improved monitoring of Stomach Tentacles; improved map coordinates (by [DCV-2142](https://github.com/DCV-2142/BigWigs))
 * MC - warning about tank knockback at Ragnaros, improved information at Thaurissan
 * ZG & AQ20 - minor fixes
 * DM North - Kromcrush fixes, new Eye of Kilrogg module
+* Naxx - improved health monitoring at Maexxna and Thaddius P1
 ## Future Ideas
 * ClickBar - Update more modules, add class-based CC options to all mind-control effects.
-* MonitorBar - Update more modules: Thekal (health), Moam (mana), Thaddius (health).
+* MonitorBar - Update more modules: Thekal (health), Moam (mana).
 * Mandokir & Buru - Properly fix rare concat errors.
-* Keeper Gnarlmoon - Identify Owls by location.
-* Chess - Keep track of major piece health and announce every % below 5.
 * Thaurissan - Are timer bars for Knockback CD feasible and helpful?
 * Rend Blackhand - Fix the event timer bars.
 * CommonAura plugin - Add a timer bar for temporary flying mounts.
 * CommonAura plugin - Add a timer bar for Tranquility from raid members.
 * CandyBar library - Potentially unregister Mouse4 and Mouse5 so they aren't captured anymore if the cursor happens to be above a bar.
-* CommonAura plugin - Look into the bug that some players sync numbers as their targets (eg Fear Ward bar).
 * Core - figure out a (non-SuperWoW) way to capture buffs/debuffs/stacks refreshing since it doesn't trigger a combat log entry.
 ## Karazhan 40 - Full Changelog
 Relative to pepopo978's BigWigs.
@@ -44,11 +42,11 @@ Relative to pepopo978's BigWigs.
 * Reworked instructions on Unstable Mana and Mana Buildup.
 * Added Shadowclaw Rager, Shadowclaw Darkbringer, Manascale Suppressor, Manascale Drake, Lingering Arcanist, Lingering Astrologist, Lingering Magus, Karazhan Protector Golem, Warbringer Overseer.
 ### Keeper Gnarlmoon
+* Accurate Owl health monitoring by location (eg "Red Front") through HP bars (default: on), replacing the Owl HP frame.
 * Added Owl Gaze warning (default: on).
 * The first Owl kill correctly shortens the Owl Phase if more than 10 seconds are left.
 * Ending the Owl Phase early will unschedule delayed warning messages.
 * Fixed Blue Moon warning sign.
-* Ravens warning can now be turned on and off during the encounter.
 * Print Troubleshoot Info (default: off): Owl deaths
 ### Incantagos
 * Added warning sign to Affinity summon.
@@ -79,6 +77,8 @@ Relative to pepopo978's BigWigs.
 * Print Troubleshoot Info (default: off): Corruption gains (not throttled), successful Shadow Bolt casts
 * Added duration bar for Corruption victim (clickable to target; default: off) for assigned healers.
 ### Chess
+* Added announcements and health bars for mindcontrol victims (default: on).
+* Added announcement when Rook/Bishop/Knight hit 8% HP (hide pre-warning; default: on).
 * Added handling for Knight's Glory. The bar for the King's Fury cast time is shortened if applied. The warning sign is now displayed for the same duration as the cast time as well.
 * Added warning for Knight's Glory (default: off) due to Knight proximity to Bishop or King so tanks can reposition.
 * Added warning and accurate timer bar for Shadow Bolt Volley cast (default: on).
@@ -101,10 +101,12 @@ Relative to pepopo978's BigWigs.
 * Added Reform timers when Fragments are defeated (default: on).
 * Added alternate triggers to no longer depend on SuperWoW cast events.
 * Added Throw Boulder mechanic - warn about the current target (default: off), mark the current target with Moon (default: on), announce incoming Boulder and Boulder miss to /say if you are the target (default: on)
-* Added Window of Opportunity handling below 15% HP boss HP in phase 1 by keeping track of Living Stone spawns to avoid Explode (default: on).
+* Added Window of Opportunity handling below 25% HP boss HP in phase 1 by keeping track of Living Stone spawns to avoid Explode (default: on).
 * Added alert for high Felheart mana (default: on).
 * Added Felheart mana bar (default: on for priests, warlocks, hunters).
 * Added Ignite Earth timers (P1 flamestrike; default: off) (idea by [DCV-2142](https://github.com/DCV-2142/BigWigs)).
+* Added health bars for Fragments in P2 (default: on).
+* Improved non-SuperWoW accuracy of Ignite Earth and Ignite Rock cast durations.
 ### Mephistroth
 * Added duration bar for Doom (default: on for druid/mage, off for everyone else), which is clickable to decurse the current Doom victim.
 * Added purge alert for Vampiric Aura (default: on for shaman/priest, off for everyone else).
@@ -118,13 +120,14 @@ Relative to pepopo978's BigWigs.
 * Added bars for minimum Shackles cooldown (default: on) and Fear cooldown (default: off) (largely by [DCV-2142](https://github.com/DCV-2142/BigWigs)).
 
 Kruul is unchanged for now.
-### Internal Changes
+## Internal Changes
 Check out the documentation subfolder for further information on many features.
 * Full support for forking.
-* New helper functions added to Core: BuffNameByIndex(), GetUnitIdByName(), GetTargetByName(), GetGUIDByName(), OffsetGUID(), RaidTargetLookup().
-* Expanded Bars plugin to add emphasis toggle, streamlined OnClick handling, and a new dynamically updating MonitorBar.
+* New helper functions added to Core: BuffNameByIndex(), GetUnitIdByName(), GetTargetByName(), GetGUIDByName(), OffsetGUID(), RaidTargetLookup(), FormatLargeNumber(), BuffIsPresent(), DebuffIsPresent(), AuraIsPresent(), GetCastTimeCoefficient(), GetHealthPercent().
+* Colors plugin provides raid target colors. Added ColorizeString().
+* Expanded Bars plugin to add emphasis toggle, streamlined OnClick handling, and a new dynamically updating MonitorBar (click to target mob).
 * Updated Babble-Zone and Babble-Boss libraries with TWoW custom names.
-### Design Principles for Contributing
+## Design Principles for Contributing
 * Avoid relying on client mods. - Where possible provide alternate triggers that don't require client mods (like SuperWoW).
 * Give players options. - Create sensible and granular settings. If a feature is only relevant to few people, do still include it but default it to off.
 * Provide actionable information that is easy to parse. - BigWigs should serve relevant information in high-pressure situations without distracting users. Examples: For an alert "Run away - Corruption!" is better than "There is Corruption of Medivh on you, you should get out of the raid". For a bar text "Alice MC" is more helpful than "Chains of Kel'Thuzad on Alice". [sidenote: this is mostly for new features; for old features there is value in keeping alerts people have grown used to]
@@ -133,15 +136,14 @@ Check out the documentation subfolder for further information on many features.
 
 If you (broadly) heed those principles I do welcome well-crafted pull requests! But please be patient and don't expect immediate reactions. BigWigs is a low-priority project for me.
 
+Frequent contributors: [DCV-2142](https://github.com/DCV-2142/BigWigs)
+
 # BigWigs (legacy description)
 BigWigs is a World of Warcraft AddOn to predict certain AI behaviour to improve the players performance.<br>
 This Modification is built for Patch 1.12.1.
 
 ## How to install
 Either clone the repository to your WoW/Interface/Addons folder, or download manually via github (click on Clone or Download -> Download ZIP. Do not forget to rename the directory to "BigWigs" afterwards.
-
-## Contributing
-If you would like to contribute, just open a pull request.
 
 ## Language support
 Currently, only english clients are supported. In general, the Addon can work with other languages, but this support is only provided on a best-effort basis. It is much effort to support those languages. Feel free to contribute if you would like to have support for other languages.

--- a/Raids/AQ40/Cthun.lua
+++ b/Raids/AQ40/Cthun.lua
@@ -834,11 +834,14 @@ end
 -- Utility Functions --
 -----------------------
 
-function GetCthunCoords(unit)
-	local posX, posY = GetPlayerMapPosition(unit)
-	posX = (18.25 * posX - 5.55) * cthunmap.map:GetWidth()
-	posY = (-12.1666666667 * posY + 5.5) * cthunmap.map:GetHeight()
-	return posX, posY
+function GetCthunCoords(unit) -- converts game map coordinates to C'Thun map coordinates
+	local posX, posY = GetPlayerMapPosition(unit) -- game map coordinates (values 0 to 1)
+	if not posX or not posY or (posX == 0 and posY == 0) then
+		return nil, nil
+	end
+	local mapX = 18.1806 * posX - 1.0604 * posY - 4.9941  -- C'Thun map X axis coordinates(values 0 to 1)
+	local mapY = -1.5906 * posX - 12.1205 * posY + 6.0044 -- C'Thun map Y axis coordinates(values 0 to -1 due to TOPLEFT anchoring)
+	return mapX * cthunmap.map:GetWidth(), mapY * cthunmap.map:GetHeight() -- calculates which pixel of the map texture the coordinates correspond to
 end
 
 function UpdateCthunMap()
@@ -849,7 +852,7 @@ function UpdateCthunMap()
 	local tooltipAnchor
 	for i = 1, 40 do
 		local coordX, coordY = GetCthunCoords("raid" .. i)
-		if coordX == 0 and coordY == 0 then
+		if not coordX or not coordY then
 			cthunmap.map.unit[i]:Hide()
 		else
 			cthunmap.map.unit[i]:Show()
@@ -1009,3 +1012,23 @@ function module:SetupMap()
 		CthunMapUnitIcon(i)
 	end
 end
+
+-- Adds command that forces the C'Thun map to appear. Use to test map and save its settings outside of the raid
+--[[
+SLASH_CTHUNMAPSHOW1 = "/cthunmapshow"
+SlashCmdList["CTHUNMAPSHOW"] = function()
+	local mod = BigWigs:GetModule("C'Thun", true)
+	if not mod then
+		DEFAULT_CHAT_FRAME:AddMessage("C'Thun module not loaded.")
+		return
+	end
+
+	if not cthunmap then
+		mod:SetupMap()
+	end
+
+	SetMapToCurrentZone()
+	cthunmap:Show()
+	DEFAULT_CHAT_FRAME:AddMessage("C'Thun map forced visible.")
+end
+--]]

--- a/Raids/AQ40/Cthun.lua
+++ b/Raids/AQ40/Cthun.lua
@@ -271,11 +271,7 @@ function module:OnRegister()
 end
 
 function module:OnEnable()
-	--self:RegisterEvent("CHAT_MSG_SAY", "Event") --Debug
-
 	self:RegisterEvent("CHAT_MSG_MONSTER_EMOTE") --trigger_weakened
-
-	--self:RegisterEvent("UNIT_HEALTH") --stomach tentacles hp
 
 	self:RegisterEvent("CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE", "Event") --trigger_cthun_eyeBeam, trigger_giantEye_eyeBeam
 
@@ -824,8 +820,9 @@ function module:CheckFleshTentacles()
 
 	local percent = UnitHealth(guidSecond) / UnitHealthMax(guidSecond) * 100
 	if percent <= 20 then
-		self:Message(string.format(L["msg_secondTentacleLow"],percent), "Urgent")
+		self:Message(string.format(L["msg_secondTentacleLow"],math.ceil(percent)), "Urgent")
 		secondTentacleLowWarn = true
+		self:CancelScheduledEvent("CthunCheckFleshTentacles")
 	end
 end
 
@@ -1013,22 +1010,4 @@ function module:SetupMap()
 	end
 end
 
--- Adds command that forces the C'Thun map to appear. Use to test map and save its settings outside of the raid
---[[
-SLASH_CTHUNMAPSHOW1 = "/cthunmapshow"
-SlashCmdList["CTHUNMAPSHOW"] = function()
-	local mod = BigWigs:GetModule("C'Thun", true)
-	if not mod then
-		DEFAULT_CHAT_FRAME:AddMessage("C'Thun module not loaded.")
-		return
-	end
-
-	if not cthunmap then
-		mod:SetupMap()
-	end
-
-	SetMapToCurrentZone()
-	cthunmap:Show()
-	DEFAULT_CHAT_FRAME:AddMessage("C'Thun map forced visible.")
-end
---]]
+-- to test the map in an empty instance: /run BigWigs:EnableModule("C'Thun", true) cthunmap:Show()

--- a/Raids/Karazhan/LordBlackwaldII.lua
+++ b/Raids/Karazhan/LordBlackwaldII.lua
@@ -56,7 +56,7 @@ local timer = {
 	boon = 15,--timer TBD
 	empoweredSoul = 10,
 	firstSummon = 30,
-	summon = 60,--unknown, is more than 40sec
+	summon = 45,
 }
 local icon = {
 	reaverstorm = "Ability_Whirlwind",

--- a/Raids/KarazhanUpper/Anomalus.lua
+++ b/Raids/KarazhanUpper/Anomalus.lua
@@ -335,8 +335,8 @@ function module:UnstableMagic(duration)
 	if bomb then -- always warn
 		self:RemoveWarningSign(icon.arcaneOverload, true) -- override bomb sign
 		self:WarningSign(icon.unstableMagic, 3, true, L["msg_unstableMagicBomb"])
-		self:Message(L["msg_unstableMagicBomb"], "Important")
-		self:Message(L["msg_unstableMagicBomb"], "Important")
+		self:Message(L["msg_unstableMagicBomb"], "Important", true, false)
+		self:Message(L["msg_unstableMagicBomb"], "Important", true, false)
 		self:Message(L["msg_unstableMagicBomb"], "Important", true, "RunAway")
 		self:Bar(L["bar_unstableMagic"], duration, icon.unstableMagic, true, "red")
 	elseif dampened and time - elapsed > duration + 0.1 and self.db.profile.unstablemagic then -- notify if enough time and enabled

--- a/Raids/KarazhanUpper/ChessFight.lua
+++ b/Raids/KarazhanUpper/ChessFight.lua
@@ -3,7 +3,7 @@ local module, L = BigWigs:ModuleDeclaration("King", "Karazhan")
 -- module variables
 module.revision = 30004
 module.enabletrigger = module.translatedName
-module.toggleoptions = { "kingsfury", "kingscursecd", "voidzone", -1, "subservienceyou", "subservienceothers", "subserviencecast", "marksubservience", "decursebow", "throttlebow", "charmingpresence", "markmindcontrol", "queensfury", -1, "shieldbashbar", "knightsglory", "bishoptonguesalert", "bishopvolley", "empoweredsb", -1, "printchess", "bosskill" }
+module.toggleoptions = { "lowhealth", "kingsfury", "kingscursecd", "voidzone", -1, "subservienceyou", "subservienceothers", "subserviencecast", "marksubservience", "decursebow", "throttlebow", "charmingpresence", "announcemindcontrol", "monitormindcontrol", "markmindcontrol", "queensfury", -1, "shieldbashbar", "knightsglory", "bishoptonguesalert", "bishopvolley", "empoweredsb", -1, "printchess", "bosskill" }
 module.zonename = {
 	AceLibrary("AceLocale-2.2"):new("BigWigs")["Tower of Karazhan"],
 	AceLibrary("Babble-Zone-2.2")["Tower of Karazhan"],
@@ -11,9 +11,11 @@ module.zonename = {
 module.wipemobs = { "Knight", "Bishop", "Rook" }
 
 local _, playerClass = UnitClass("player")
+local lowHealthThreshold = 8
 
 -- module defaults
 module.defaultDB = {
+	lowhealth = true,
 	kingsfury = true,
 	kingscursecd = true,
 	voidzone = true,
@@ -24,11 +26,13 @@ module.defaultDB = {
 	decursebow = playerClass == "MAGE" or playerClass == "DRUID",
 	throttlebow = true,
 	charmingpresence = playerClass == "SHAMAN",
+	announcemindcontrol = true,
+	monitormindcontrol = true,
 	markmindcontrol = true,
 	queensfury = false,
 	shieldbashbar = false,
 	knightsglory = false,
-	bishoptonguesalert = true,
+	bishoptonguesalert = IsRaidLeader() or playerClass == "WARLOCK",
 	bishopvolley = true,
 	empoweredsb = false,
 	printchess = false,
@@ -38,6 +42,10 @@ module.defaultDB = {
 L:RegisterTranslations("enUS", function()
 	return {
 		cmd = "ChessEvent",
+
+		lowhealth_cmd = "lowhealth",
+		lowhealth_name = "Piece Low HP Warning",
+		lowhealth_desc = "Warns when Rook/Bishop/Knight fall to "..lowHealthThreshold.."% HP to predict incoming King's Fury",
 
 		kingsfury_cmd = "kingsfury",
 		kingsfury_name = "King's Fury Alert",
@@ -79,9 +87,17 @@ L:RegisterTranslations("enUS", function()
 		charmingpresence_name = "Charming Presence Timer",
 		charmingpresence_desc = "Shows a timer for when the Queen will cast Charming Presence",
 
+		announcemindcontrol_cmd = "announcemindcontrol",
+		announcemindcontrol_name = "Announce Charmed Targets",
+		announcemindcontrol_desc = "Warns when a player gets mind controlled by the Queen (Charming Presence)",
+
+		monitormindcontrol_cmd = "monitormindcontrol",
+		monitormindcontrol_name = "Monitor Charmed Targets",
+		monitormindcontrol_desc = "Shows a health bar for all players affected by Charming Presence",
+
 		markmindcontrol_cmd = "markmindcontrol",
-		markmindcontrol_name = "Mark Mind Controlled Target",
-		markmindcontrol_desc = "Marks players affected by King's Curse with X raid icon (requires assistant or leader)",
+		markmindcontrol_name = "Mark Charmed Target",
+		markmindcontrol_desc = "Marks players affected by Charming Presence with X raid icon (requires assistant or leader)",
 
 		queensfury_cmd = "queensfury",
 		queensfury_name = "Queen's Fury Magnitude",
@@ -117,16 +133,17 @@ L:RegisterTranslations("enUS", function()
 
 		trigger_subservienceYou = "You are afflicted by Dark Subservience",
 		trigger_subservienceOther = "(.+) is afflicted by Dark Subservience",
-		trigger_subservienceFade = "Dark Subservience fades from (.+)",
+		trigger_subservienceFade = "Dark Subservience fades from (.+)%.",
 		trigger_subservienceFailed = "Dark Subservience fails. Grounding Totem", --not observed in logs since April 2025
 
 		trigger_kingscurseYou = "You are afflicted by King's Curse", --unused
 		trigger_kingscurseOther = "(.+) is afflicted by King's Curse",
-		trigger_kingscurseFade = "King's Curse fades from (.+)",
+		trigger_kingscurseFade = "King's Curse fades from (.+)%.",
 
 		trigger_charmingPresenceYou = "You are afflicted by Charming Presence",
 		trigger_charmingPresenceOther = "(.+) is afflicted by Charming Presence",
-		trigger_charmingPresenceFade = "Charming Presence fades from (.+)",
+		trigger_charmingPresenceEnemy = "(.+) %(Queen%) is afflicted by Charming Presence",
+		trigger_charmingPresenceFade = "Charming Presence fades from (.+)%.",
 		
 		trigger_queensfury = "Queen gains (.+) Fury %((%d+)%)%.",
 
@@ -144,20 +161,22 @@ L:RegisterTranslations("enUS", function()
 		msg_kingFurySafe = "Safe!",
 		msg_voidzone = "Void Zone MOVE!",
 
-		msg_subservienceYou = "YOU need to go Bow to the Queen!",
+		msg_subservienceYou = "YOU need Bow to the Queen!",
 		msg_subservienceOther = "%s needs to go Bow!",
 		msg_queenCastingSubservience = "Queen began casting on %s!",
-		msg_queenCastingSubservienceYou = "Dark Subservience incoming! Get ready to /bow (unless grounded).",
+		msg_queenCastingSubservienceYou = "Dark Subservience incoming! Get ready to /bow.",
 		msg_queenSubservienceTotem = "Totem ate cast instead of %s!",
 		msg_queenSubservienceTotemYou = "Safe from /bow! Totem ate cast.",
+		msg_charmingPresence = "Mind Control on %s",
 		msg_queensfury = "Queen's Fury %s ticking for ",
 
 		warning_bow = "BOW TO THE QUEEN!",
 		warn_kingsfury = "HIDE",
 
-		bar_subservience = "Go right in front of Queen and Bow! >Click Me<",
+		bar_subservience = ">Bow to Queen<",
 		bar_kingsfury = "King's Fury - Hide!",
 		bar_charmingpresence = "Next Charming Presence",
+		bar_mc = "MC on %s",
 		bar_decursebow = (playerClass=="MAGE" and ">Decurse %s!< for /bow") or (playerClass=="DRUID" and ">Decurse %s!< for bow") or "Decurse %s for /bow",
 		spell_decursebow = (playerClass=="MAGE" and "Remove Lesser Curse") or (playerClass=="DRUID" and "Remove Curse") or false,
 		bar_curseCD = "King's Curse on CD",
@@ -176,6 +195,8 @@ L:RegisterTranslations("enUS", function()
 		trigger_subservienceHit = "(.+) suffers (.+) Shadow damage from Queen's Dark Subservience",
 		
 		bar_shieldbash = "Shield Bash CD",
+		
+		msg_lowHealth = "Hide Phase Soon! - %s at "..lowHealthThreshold.."%%",
 	}
 end)
 
@@ -209,7 +230,8 @@ local syncName = {
 	queenCastingSubservience = "ChessQueenCastingSubservience" .. module.revision,
 	kingCastFury = "ChessKingCastFury" .. module.revision,
 	subservienceFailed = "ChessSubservienceFailed" .. module.revision,
-	charmingPresence = "ChessCharmingPresence" .. module.revision,
+	charmingPresenceCast = "ChessCharmingPresence" .. module.revision,
+	charmingPresence = "ChessQueenMC" .. module.revision,
 	queensfury = "ChessQueensFury" .. module.revision,
 	bishopNoCurse = "ChessBishopNoCurse" .. module.revision,
 	voidzone = "ChessVoidZone" .. module.revision,
@@ -230,12 +252,21 @@ local spellIds = {
 	kingscurse = 41635,
 	blunder = 52667, -- Void Zone
 	shieldbash = 51219, -- Shield Bash
+	tongues = 11719, -- Curse of Tongues rank 2
+}
+
+local guid = {
+	king = "0xF13000EA3F276C05",
+	bishop = "0xF13000EA43276C06",
+	rook = "0xF13000EA42276C07",
+	knight = "0xF13000EA40276C08",
 }
 
 local bowed = {}
 local bishopHasTongues = 0
 local bishopHasGlory = 0
 local kingHasGlory = 0
+local scanTargets = {}
 
 local baseChatFrameOnEvent = ChatFrame_OnEvent
 
@@ -243,8 +274,9 @@ function module:OnEnable()
 	self:RegisterEvent("CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE", "AfflictionEvent")
 	self:RegisterEvent("CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE", "AfflictionEvent")
 	self:RegisterEvent("CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE", "AfflictionEvent")
+	self:RegisterEvent("CHAT_MSG_SPELL_PERIODIC_HOSTILEPLAYER_DAMAGE", "AfflictionEvent")
 
-	self:RegisterEvent("CHAT_MSG_SPELL_AURA_GONE_SELF")
+	self:RegisterEvent("CHAT_MSG_SPELL_AURA_GONE_SELF", "FadesEvent")
 	self:RegisterEvent("CHAT_MSG_SPELL_AURA_GONE_PARTY", "FadesEvent")
 	self:RegisterEvent("CHAT_MSG_SPELL_AURA_GONE_OTHER", "FadesEvent")
 
@@ -255,10 +287,6 @@ function module:OnEnable()
 
 	self:RegisterEvent("CHAT_MSG_SPELL_PERIODIC_CREATURE_BUFFS", "EnemyDebuffEvent")
 	self:RegisterEvent("CHAT_MSG_SPELL_PERIODIC_CREATURE_DAMAGE", "EnemyDebuffEvent")
-
-	if self.db.profile.bishoptonguesalert then
-		self:ScheduleRepeatingEvent("BishopDebuffScan", self.ScanBishopDebuffs, timer.bishopScan, self)
-	end
 
 	-- install wrapper exactly once
 	if not self.origChatFrameOnEvent and self.db.profile.throttlebow then
@@ -298,6 +326,7 @@ function module:OnEnable()
 	self:ThrottleSync(2, syncName.queenCastingSubservience)
 	self:ThrottleSync(2, syncName.kingCastFury)
 	self:ThrottleSync(2, syncName.subservienceFailed)
+	self:ThrottleSync(2, syncName.charmingPresenceCast)
 	self:ThrottleSync(2, syncName.charmingPresence)
 	self:ThrottleSync(5, syncName.queensfury)
 	self:ThrottleSync(2, syncName.bishopNoCurse)
@@ -333,11 +362,21 @@ function module:OnEngage()
 
 	self.queenTarget = ""
 
+	if self.db.profile.bishoptonguesalert then
+		self:ScheduleRepeatingEvent("BishopDebuffScan", self.ScanBishopDebuffs, timer.bishopScan, self)
+	end
+
+	if self.db.profile.lowhealth then
+		scanTargets = { guid.rook, guid.bishop, guid.knight }
+		self:ScheduleRepeatingEvent("ChessHealthCheck", self.CheckHealth, 0.25, self)
+	end
+
 	self:ShieldBash()
 end
 
 function module:OnDisengage()
 	self:CancelScheduledEvent("BishopDebuffScan")
+	self:CancelScheduledEvent("ChessHealthCheck")
 end
 
 function module:QueenCastEvent(casterGuid, targetGuid, eventType, spellId, castTime)
@@ -345,7 +384,7 @@ function module:QueenCastEvent(casterGuid, targetGuid, eventType, spellId, castT
 		self.queenTarget = UnitName(targetGuid) or ""
 		self:Sync(syncName.queenCastingSubservience .. " " .. self.queenTarget)
 	elseif spellId == spellIds.charmingpresence and eventType == "CAST" then
-		self:Sync(syncName.charmingPresence)
+		self:Sync(syncName.charmingPresenceCast)
 	end
 end
 
@@ -407,32 +446,19 @@ function module:AfflictionEvent(msg)
 	end
 
 	-- Charming Presence
-	local _, _, player = string.find(msg, L["trigger_charmingPresenceOther"])
-	if player and self.db.profile.markmindcontrol then
-		-- Mark the player with X raid target
-		self:SetRaidTargetForPlayer(player, 7) -- X
-		return
+	if string.find(msg, L["trigger_charmingPresenceYou"]) then
+		self:Sync(syncName.charmingPresence .. " " .. UnitName("player"))
+	else
+		local _, _, player = string.find(msg, L["trigger_charmingPresenceEnemy"])
+		if player then
+			self:Sync(syncName.charmingPresence .. " " .. player)
+		end
 	end
 	
 	-- King's Curse on anyone (just for timing the CD)
 	if string.find(msg, L["trigger_kingscurseOther"]) then
 		self:Sync(syncName.curseHappened)
 		return
-	end
-end
-
-function module:CHAT_MSG_SPELL_AURA_GONE_SELF(msg)
-	if string.find(msg, L["trigger_subservienceFade"]) then
-		self:RemoveBar(L["bar_subservience"])
-		self:RemoveWarningSign(icon.subservience, true)
-		self:Sound("Long")
-
-		if self.db.profile.marksubservience then
-			self:RestorePreviousRaidTargetForPlayer(UnitName("player"))
-		end
-	elseif string.find(msg, L["trigger_kingscurseFade"]) then
-		local player = UnitName("player")
-		self:RemoveBar(string.format(L["bar_decursebow"], player))
 	end
 end
 
@@ -470,12 +496,19 @@ end
 function module:FadesEvent(msg)
 	local _, _, player = string.find(msg, L["trigger_kingscurseFade"])
 	if player then
+		player = player == "you" and UnitName("player") or player
 		self:RemoveBar(string.format(L["bar_decursebow"], player))
 		return
 	end
 
 	_, _, player = string.find(msg, L["trigger_subservienceFade"])
 	if player then
+		if player == "you" then
+			self:RemoveBar(L["bar_subservience"])
+			self:RemoveWarningSign(icon.subservience, true)
+			self:Sound("Long")
+			player = UnitName("player")
+		end
 		if self.db.profile.marksubservience then
 			self:RestorePreviousRaidTargetForPlayer(player)
 		end
@@ -485,9 +518,8 @@ function module:FadesEvent(msg)
 
 	_, _, player = string.find(msg, L["trigger_charmingPresenceFade"])
 	if player then
-		if self.db.profile.markmindcontrol then
-			self:RestorePreviousRaidTargetForPlayer(player)
-		end
+		player = player == "you" and UnitName("player") or player
+		self:CharmingPresenceOver(player)
 		return
 	end
 	
@@ -512,10 +544,11 @@ function module:OnFriendlyDeath(msg)
 	local _, _, player = string.find(msg, "(.+) dies")
 	if player then
 		-- Remove raid marks for players who die
-		if self.db.profile.marksubservience or self.db.profile.markmindcontrol then
+		if self.db.profile.marksubservience then
 			self:RestorePreviousRaidTargetForPlayer(player)
 		end
 
+		self:CharmingPresenceOver(player)
 		self:RemoveBar(string.format(L["bar_decursebow"], player))
 	end
 end
@@ -529,13 +562,13 @@ function module:BigWigs_RecvSync(sync, rest, nick)
 		self:KingCastFury()
 	elseif sync == syncName.subservienceFailed and rest then
 		self:SubservienceFailed(rest)
-	elseif sync == syncName.charmingPresence then
-		if self.db.profile.charmingpresence then
-			self:StartCharmingPresenceTimer()
-		end
+	elseif sync == syncName.charmingPresenceCast then
+		self:StartCharmingPresenceTimer()
+	elseif sync == syncName.charmingPresence and rest then
+		self:CharmingPresence(rest)
 	elseif sync == syncName.queensfury and rest then
 		if self.db.profile.queensfury then
-			self:Message(string.format(L["msg_queensfury"], rest)..(tonumber(rest)*70), "Purple")
+			self:Message(string.format(L["msg_queensfury"], rest)..(tonumber(rest)*70), "Magenta", true, false)
 		end
 	elseif sync == syncName.bishopNoCurse then
 		self:BishopNeedsCurseOfTongues()
@@ -549,7 +582,7 @@ function module:BigWigs_RecvSync(sync, rest, nick)
 	elseif sync == syncName.kingGloryFade then
 		kingHasGlory = 0
 		if self.db.profile.knightsglory then
-			self:Message(string.format(L["msg_gloryFade"], module.translatedName), "Positive", nil, "Alert")
+			self:Message(string.format(L["msg_gloryFade"], module.translatedName), "Positive", true, "Alert")
 		end
 	elseif sync == syncName.bishopGloryGain then
 		bishopHasGlory = 1
@@ -559,7 +592,7 @@ function module:BigWigs_RecvSync(sync, rest, nick)
 	elseif sync == syncName.bishopGloryFade then
 		bishopHasGlory = 0
 		if self.db.profile.knightsglory then
-			self:Message(string.format(L["msg_gloryFade"], L["bishop_name"]), "Positive", nil, "Alert")
+			self:Message(string.format(L["msg_gloryFade"], L["bishop_name"]), "Positive", true, "Alert")
 		end
 	elseif sync == syncName.bishopTonguesGain then
 		bishopHasTongues = 1
@@ -585,7 +618,7 @@ end
 function module:QueenCastingSubservience(playerName)
 	self.queenTarget = playerName
 	if playerName == UnitName("player") and self.db.profile.subservienceyou then
-		self:Message(L["msg_queenCastingSubservienceYou"], "Urgent", nil, "Beware")
+		self:Message(L["msg_queenCastingSubservienceYou"], "Urgent", true, "Beware")
 	elseif self.db.profile.subserviencecast then
 		self:Message(string.format(L["msg_queenCastingSubservience"], playerName), "Attention", nil, "Info")
 	end	
@@ -593,15 +626,15 @@ end
 
 function module:SubservienceFailed(playerName) --might be defunct
 	if playerName == UnitName("player") and self.db.profile.subservienceyou then
-		self:Message(L["msg_queenSubservienceTotemYou"], "Positive", nil, "Long")
+		self:Message(L["msg_queenSubservienceTotemYou"], "Positive", true, "Long")
 	elseif self.db.profile.subserviencecast then
-		self:Message(string.format(L["msg_queenSubservienceTotem"], playerName), "Positive")
+		self:Message(string.format(L["msg_queenSubservienceTotem"], playerName), "Positive", true, false)
 	end	
 end
 
 function module:Subservience(player)
 	if player == UnitName("player") and self.db.profile.subservienceyou then
-		self:Message(L["msg_subservienceYou"], "Important")
+		self:Message(L["msg_subservienceYou"], "Important", true)
 		self:WarningSign(icon.subservience, timer.subservience, true, L["warning_bow"])
 		self:Bar(L["bar_subservience"], timer.subservience, icon.subservience)
 
@@ -667,12 +700,12 @@ function module:KingCastFury()
 	if kingHasGlory == 1 then
 		self:Message(L["msg_kingCastFuryFast"], "Attention", nil, "Beware")
 	else
-		self:Message(L["msg_kingCastFury"], "Attention", nil, "Info")
+		self:Message(L["msg_kingCastFury"], "Attention", nil, "Hide")
 	end
 	local castTime = timer.kingsfury / (1 + (0.5 * kingHasGlory))
 	self:Bar(L["bar_kingsfury"], castTime, icon.kingsfury)
 	self:WarningSign(icon.kingsfury, castTime, true, L["warn_kingsfury"])
-	self:DelayedMessage(castTime+0.2, L["msg_kingFurySafe"], "Positive", false, "Long", false)
+	self:DelayedMessage(castTime+0.2, L["msg_kingFurySafe"], "Positive", nil, "Long")
 end
 
 function module:VoidZoneAlert(player)
@@ -681,49 +714,29 @@ function module:VoidZoneAlert(player)
 	end
 
 	if player == UnitName("player") then
-		self:Message(L["msg_voidzone"], "Important", nil, "Alarm")
+		self:Message(L["msg_voidzone"], "Important", true, "VoidZoneMove")
 		self:WarningSign(icon.voidzone, timer.voidzone, true, L["msg_voidzone"])
-		self:Sound("VoidZoneMove")
 		SendChatMessage("Void Zone On Me!", "SAY")
 	end
 end
 
 function module:ScanBishopDebuffs()
-	-- Check if current target is Bishop
-	if UnitName("target") == L["bishop_name"] then
-		-- Scan debuffs
-		for i = 1, 16 do
-			local texture = UnitDebuff("target", i)
-			if texture and string.find(texture, "Spell_Shadow_CurseOfTounges") then
-				-- Found Curse of Tongues debuff
-				return
-			elseif not texture then
-				break
-			end
+	if UnitExists(guid.bishop) then
+		if UnitIsDead(guid.bishop) then
+			self:CancelScheduledEvent("BishopDebuffScan")
+			return
 		end
-
-		-- Scan buffs
-		for i = 1, 32 do
-			local texture = UnitBuff("target", i)
-			if texture and string.find(texture, "Spell_Shadow_CurseOfTounges") then
-				-- Found Curse of Tongues as buff
-				return
-			elseif not texture then
-				break
-			end
+		if not BigWigs:AuraIsPresent(guid.bishop, spellIds.tongues) then
+			-- no curse of tongues found, trigger sync
+			self:Sync(syncName.bishopNoCurse)
 		end
-
-		-- no curse of tongues found, trigger sync
-		self:Sync(syncName.bishopNoCurse)
 	end
 end
 
 function module:BishopNeedsCurseOfTongues()
+	bishopHasTongues = 0
 	if self.db.profile.bishoptonguesalert then
-		if IsRaidLeader() or playerClass == "WARLOCK" then
-			-- Alert warlocks that the Bishop needs to be cursed
-			self:Message(L["bishop_needsTongues"], "Important", nil, "Alert")
-		end
+		self:Message(L["bishop_needsTongues"], "Important", nil, "Alert")
 	end
 end
 
@@ -731,7 +744,7 @@ function module:ShadowBoltVolley()
 	if self.db.profile.bishopvolley then
 		local castTime = timer.sbvolley * (1 + bishopHasTongues * 0.6) / (1 + bishopHasGlory * 0.5)
 		self:Bar(L["bar_bishopVolley"], castTime, icon.sbvolley)
-		self:Message(L["msg_bishopVolley"], "purple", nil, "Alarm")
+		self:Message(L["msg_bishopVolley"], "Purple", nil, "Alarm")
 	end
 end
 
@@ -749,6 +762,45 @@ function module:ShieldBash()
 	end
 end
 
+function module:CharmingPresence(player)
+	if self.db.profile.announcemindcontrol then
+		self:Message(string.format(L["msg_charmingPresence"], player), "Core", nil, "Info")
+	end
+
+	if self.db.profile.monitormindcontrol then
+		self:MonitorBar(player.." MC", icon.charmingpresence, BigWigs:GetGUIDByName(player, 0), "health", string.format(L["bar_mc"], player))
+	end
+
+	-- Mark the player with X raid target
+	if self.db.profile.markmindcontrol then
+		self:SetRaidTargetForPlayer(player, 7) -- X
+	end
+end
+
+function module:CharmingPresenceOver(player)
+	self:RemoveBar(player.." MC")
+
+	if self.db.profile.markmindcontrol then
+		self:RestorePreviousRaidTargetForPlayer(player)
+	end
+end
+
+function module:CheckHealth()
+	local count = table.getn(scanTargets)
+	if (not self.db.profile.lowhealth) or count == 0 then
+		self:CancelScheduledEvent("ChessHealthCheck")
+		return
+	end
+	for i=1,count do
+		local percent = BigWigs:GetHealthPercent(scanTargets[i])
+		if percent and percent < lowHealthThreshold then
+			self:Message(string.format(L["msg_lowHealth"], UnitName(scanTargets[i])), "Attention")	
+			table.remove(scanTargets, i)
+			break
+		end
+	end
+end
+
 function module:Test()
 	-- Initialize module state
 	self:OnSetup()
@@ -763,14 +815,14 @@ function module:Test()
 		-- King's Curse events
 		{ time = 1, func = function()
 			-- Simulate actual message format
-			local msg = originalPlayer .. " is afflicted by King's Curse"
+			local msg = originalPlayer .. " is afflicted by King's Curse."
 			module:AfflictionEvent(msg)
 			print("Test: " .. msg)
 		end },
 
 		{ time = 1, func = function()
 			-- Simulate actual message format
-			local msg = testPlayerName1 .. " is afflicted by King's Curse"
+			local msg = testPlayerName1 .. " is afflicted by King's Curse."
 			module:AfflictionEvent(msg)
 			print("Test: " .. msg)
 		end },
@@ -785,31 +837,31 @@ function module:Test()
 
 		-- Subservience events for self
 		{ time = 3, func = function()
-			local msg = "You are afflicted by Dark Subservience"
+			local msg = "You are afflicted by Dark Subservience."
 			module:AfflictionEvent(msg)
 			print("Test: " .. msg)
 		end },
 
 		{ time = 5, func = function()
 			print("Test: Scanning Bishop")
-			local originalName = L["bishop_name"]
-			L["bishop_name"] = UnitName("target")
+			local originalGuid = guid.bishop
+			_, guid.bishop = UnitExists("target")
 
 			-- Run the scan function
 			module:ScanBishopDebuffs()
 
-			-- Restore original name
-			L["bishop_name"] = originalName
+			-- Restore original GUID
+			guid.bishop = originalGuid
 		end },
 
 		{ time = 7, func = function()
 			print("Test: Queen begins to cast Charming Presence")
-			module:Sync(syncName.charmingPresence)
+			module:Sync(syncName.charmingPresenceCast)
 		end },
 
 		{ time = 9, func = function()
-			local msg = "Dark Subservience fades from you"
-			module:CHAT_MSG_SPELL_AURA_GONE_SELF(msg)
+			local msg = "Dark Subservience fades from you."
+			module:FadesEvent(msg)
 			print("Test: " .. msg)
 		end },
 
@@ -827,22 +879,34 @@ function module:Test()
 			print("Test: " .. msg)
 		end },
 
+		{ time = 13, func = function()
+			local msg = "You are afflicted by Charming Presence."
+			self:TriggerEvent("CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE", msg)
+			print("Test: " .. msg)
+		end },
+
 		{ time = 18, func = function()
-			local msg = "Dark Subservience fades from " .. testPlayerName1
+			local msg = "Dark Subservience fades from " .. testPlayerName1.."."
 			module:FadesEvent(msg)
+			print("Test: " .. msg)
+		end },
+
+		{ time = 19, func = function()
+			local msg = "Charming Presence fades from you."
+			self:TriggerEvent("CHAT_MSG_SPELL_AURA_GONE_SELF", msg)
 			print("Test: " .. msg)
 		end },
 
 		-- Test King's Curse fading
 		{ time = 20, func = function()
-			local msg = "King's Curse fades from " .. testPlayerName1
+			local msg = "King's Curse fades from " .. testPlayerName1.."."
 			module:FadesEvent(msg)
 			print("Test: " .. msg)
 		end },
 
 		-- Test SBV from Bishop
 		{ time = 22, func = function()
-			local msg = "Bishop begins to cast Shadow Bolt Volley"
+			local msg = "Bishop begins to cast Shadow Bolt Volley."
 			module:SpellEvent(msg)
 			print("Test: " .. msg)
 		end },
@@ -874,23 +938,28 @@ function module:Test()
 			print("Test: " .. msg)
 		end },
 
+		{ time = 29, func = function()
+			local msg = testPlayerName2 .. " (Queen) is afflicted by Charming Presence."
+			self:TriggerEvent("CHAT_MSG_SPELL_PERIODIC_HOSTILEPLAYER_DAMAGE", msg)
+			print("Test: " .. msg)
+		end },
+
 		-- Test player death with debuffs
 		{ time = 30, func = function()
-			local msg = testPlayerName2 .. " is afflicted by Dark Subservience"
+			local msg = testPlayerName2 .. " is afflicted by Dark Subservience."
 			module:AfflictionEvent(msg)
 			module:DecurseReminder(testPlayerName2)
 			print("Test: " .. msg)
 		end },
 
 		{ time = 31, func = function()
-			local msg = testPlayerName2 .. " is afflicted by King's Curse"
+			local msg = testPlayerName2 .. " is afflicted by King's Curse."
 			module:AfflictionEvent(msg)
 			print("Test: " .. msg)
 		end },
 
 		{ time = 32, func = function()
-			local msg = testPlayerName2 .. " dies"
-			-- Correct event for player death is CHAT_MSG_COMBAT_FRIENDLY_DEATH
+			local msg = testPlayerName2 .. " dies."
 			module:OnFriendlyDeath(msg)
 			print("Test: " .. msg)
 		end },
@@ -898,14 +967,14 @@ function module:Test()
 		-- Add to the events table inside the Test function
 		{ time = 33, func = function()
 			print("Test: Scanning Bishop")
-			local originalName = L["bishop_name"]
-			L["bishop_name"] = UnitName("target")
+			local originalGuid = guid.bishop
+			_, guid.bishop = UnitExists("target")
 
 			-- Run the scan function
 			module:ScanBishopDebuffs()
 
-			-- Restore original name
-			L["bishop_name"] = originalName
+			-- Restore original GUID
+			guid.bishop = originalGuid
 		end },
 
 		-- CoT on Bishop
@@ -931,20 +1000,20 @@ function module:Test()
 
 		-- King's Fury event
 		{ time = 36, func = function()
-			local msg = "King begins to cast King’s Fury"
+			local msg = "King begins to cast King’s Fury."
 			module:SpellEvent(msg)
 			print("Test: " .. msg)
 		end },
 
 		-- First Shield Bash
 		{ time = 37, func = function()
-			print("Test: Rook casts Shield Bash")
+			print("Test: Rook casts Shield Bash.")
 			module:ShieldBash()
 		end },
 
 		-- Test SBV from Bishop with full length
 		{ time = 38, func = function()
-			local msg = "Bishop begins to cast Shadow Bolt Volley"
+			local msg = "Bishop begins to cast Shadow Bolt Volley."
 			module:SpellEvent(msg)
 			print("Test: " .. msg)
 		end },

--- a/Raids/KarazhanUpper/EchoOfMedivh.lua
+++ b/Raids/KarazhanUpper/EchoOfMedivh.lua
@@ -283,7 +283,7 @@ function module:FadesEvent(msg)
 		self:CorruptionFade(player)
 	end
 	if self.db.profile.irestacks and string.find(msg, L["trigger_ireFade"]) then
-		self:Message(string.format(L["msg_ire"], 0), "Positive")
+		self:Message(string.format(L["msg_ire"], 0), "Positive", true, "Long")
 		self:RemoveBar(L["bar_ire"])
 	end
 end
@@ -295,7 +295,7 @@ function module:CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE(msg)
 			self:Message(string.format(L["msg_cast"], spell), "Important", true, "Info")
 			self:WarningSign(icon.frostnova, 1, false, L["warn_cast"])
 		elseif self.db.profile.castshadowbolt and spell == L["spell_ShadowBolt"] then
-			self:Message(string.format(L["msg_cast"], spell), "Urgent", true, "Alarm")
+			self:Message(string.format(L["msg_cast"], spell), "Urgent", nil, "Alarm")
 			self:WarningSign(icon.shadowbolt, 1, true, L["warn_cast"])
 		elseif self.db.profile.castpyroblast and spell == L["spell_Pyroblast"] then
 			self:Message(string.format(L["msg_cast"], spell), "Important", true, "Info")
@@ -332,7 +332,7 @@ function module:CHAT_MSG_SPELL_PERIODIC_CREATURE_BUFFS(msg)
 			ire = tonumber(str)
 		end
 		if ire then
-			self:Message(string.format(L["msg_ire"], ire), "Attention")
+			self:Message(string.format(L["msg_ire"], ire), "Attention", true, false)
 			self:Bar(L["bar_ire"], timer.ireReset, icon.ire)
 		end
 	end
@@ -417,7 +417,7 @@ end
 
 function module:ArcaneFocus(player)
 	if self.db.profile.arcanefocus then
-		self:Message(string.format(L["msg_arcanefocus"], player), "Important")
+		self:Message(string.format(L["msg_arcanefocus"], player), "Important", true)
 		self:WarningSign(icon.focus, 2, false, string.format(L["warn_arcanefocus"], player))
 	end
 end
@@ -463,11 +463,11 @@ function module:CancelRestoPot()
 	if GetPlayerBuffID then
 		-- use spell id if superwow available to avoid potentially canceling the wrong buff
 		if BigWigs:CancelAuraId(11359) then
-			self:Message(L["resto_pot_cancelling"], "Positive")
+			self:Message(L["resto_pot_cancelling"], "Positive", true, false)
 		end
 	else
 		if BigWigs:CancelAuraTexture("Spell_Holy_DispelMagic") then
-			self:Message(L["resto_pot_cancelling"], "Positive")
+			self:Message(L["resto_pot_cancelling"], "Positive", true, false)
 		end
 	end
 end

--- a/Raids/KarazhanUpper/Incantagos.lua
+++ b/Raids/KarazhanUpper/Incantagos.lua
@@ -371,7 +371,7 @@ function module:BuffEvent(msg)
 		self:Sync(syncName.crystalAffinity)
 	elseif string.find(msg, L["trigger_berserk"]) then
 		self:WarningSign(icon.berserk, 2, true, L["warn_berserk"])
-		self:Message(L["msg_berserk"], "Urgent", true, "Murloc")
+		self:Message(L["msg_berserk"], "Urgent", nil, "Murloc")
 	end
 end
 
@@ -409,7 +409,7 @@ function module:DebuffEvent(msg)
 	if player then
 		self:SurgeBar(player)
 		if self.db.profile.surgewarning then
-			self:Message(string.format(L["msg_surge"], player), "Attention", true, "Info")			
+			self:Message(string.format(L["msg_surge"], player), "Attention", nil, "Info")			
 		end
 	end
 end
@@ -491,7 +491,7 @@ end
 
 function module:LeyLine()
 	if self.db.profile.leyline then
-		self:Message(L["msg_leyLine"], "Important", true, "Beware")
+		self:Message(L["msg_leyLine"], "Important", nil, "Beware")
 		self:WarningSign(icon.leyLine, 3, false, L["warn_leyLine"])
 		self:RemoveBar(L["bar_leyLineCD"])
 		self:Bar(L["bar_leyLineCast"], timer.leyLineCast, icon.leyLine, true, color.leyLine)
@@ -501,7 +501,7 @@ end
 
 function module:BlackAffinity()
 	if self.db.profile.affinity then
-		self:Message(L["msg_blackAffinity"], "Important", true, "Alarm")
+		self:Message(L["msg_blackAffinity"], "Important", nil, "Alarm")
 		self:WarningSign(icon.blackAffinity, 5, true, L["warn_blackAffinity"])
 		self:ClickBar(L["bar_blackAffinity"], timer.affinity, icon.blackAffinity, L["unit_blackAffinity"])
 	end
@@ -512,7 +512,7 @@ end
 
 function module:BlueAffinity()
 	if self.db.profile.affinity then
-		self:Message(L["msg_blueAffinity"], "Important", true, "Alarm")
+		self:Message(L["msg_blueAffinity"], "Important", nil, "Alarm")
 		self:WarningSign(icon.blueAffinity, 5, true, L["warn_blueAffinity"])
 		self:ClickBar(L["bar_blueAffinity"], timer.affinity, icon.blueAffinity, L["unit_blueAffinity"])
 	end
@@ -523,7 +523,7 @@ end
 
 function module:CrystalAffinity()
 	if self.db.profile.affinity then
-		self:Message(L["msg_crystalAffinity"], "Important", true, "Alarm")
+		self:Message(L["msg_crystalAffinity"], "Important", nil, "Alarm")
 		self:WarningSign(icon.crystalAffinity, 5, true, L["warn_crystalAffinity"])
 		self:ClickBar(L["bar_crystalAffinity"], timer.affinity, icon.crystalAffinity, L["unit_crystalAffinity"])
 	end
@@ -534,7 +534,7 @@ end
 
 function module:GreenAffinity()
 	if self.db.profile.affinity then
-		self:Message(L["msg_greenAffinity"], "Important", true, "Alarm")
+		self:Message(L["msg_greenAffinity"], "Important", nil, "Alarm")
 		self:WarningSign(icon.greenAffinity, 5, true, L["warn_greenAffinity"])
 		self:ClickBar(L["bar_greenAffinity"], timer.affinity, icon.greenAffinity, L["unit_greenAffinity"])
 	end
@@ -545,7 +545,7 @@ end
 
 function module:ManaAffinity()
 	if self.db.profile.affinity then
-		self:Message(L["msg_manaAffinity"], "Important", true, "Alarm")
+		self:Message(L["msg_manaAffinity"], "Important", nil, "Alarm")
 		self:WarningSign(icon.manaAffinity, 5, true, L["warn_manaAffinity"])
 		self:ClickBar(L["bar_manaAffinity"], timer.affinity, icon.manaAffinity, L["unit_manaAffinity"])
 	end
@@ -556,7 +556,7 @@ end
 
 function module:RedAffinity()
 	if self.db.profile.affinity then
-		self:Message(L["msg_redAffinity"], "Important", true, "Alarm")
+		self:Message(L["msg_redAffinity"], "Important", nil, "Alarm")
 		self:WarningSign(icon.redAffinity, 5, true, L["warn_redAffinity"])
 		self:ClickBar(L["bar_redAffinity"], timer.affinity, icon.redAffinity, L["unit_redAffinity"])
 	end
@@ -582,7 +582,7 @@ end
 
 function module:AllSeekersDead()
 	self.seekersLeft = 0
-	self:Message(L["msg_seekerDeath"], "Positive")
+	self:Message(L["msg_seekerDeath"], "Positive", nil, "Long")
 	
 	if self.db.profile.leyline then
 		self:IntervalBar(L["bar_leyLineCD"], timer.firstLeyLine[1], timer.firstLeyLine[2], icon.leyLine, true, color.leyLine)

--- a/Raids/KarazhanUpper/KaraTrash.lua
+++ b/Raids/KarazhanUpper/KaraTrash.lua
@@ -393,11 +393,11 @@ function module:AfflictionEvent(msg)
 		return
 	end
 	if string.find(msg, L["trigger_arcanist_blizzard"]) then
-		self:Message(L["msg_arcanist_blizzard"], "Attention", nil, "Info")
+		self:Message(L["msg_arcanist_blizzard"], "Attention", true, "Info")
 		self:WarningSign(icon.arcanist_blizzard, 2, false, L["warn_arcanist_blizzard"])
 	end
 	if string.find(msg, L["trigger_astrologist_insight"]) then
-		self:Message(L["msg_astrologist_insight"], "Important", nil, "Beware")
+		self:Message(L["msg_astrologist_insight"], "Important", true, "Beware")
 		self:WarningSign(icon.astrologist_insight, 7, true, L["warn_astrologist_insight"])
 	end
 	if string.find(msg, L["trigger_astrologist_rain"]) then
@@ -409,7 +409,7 @@ function module:RemoveEvent(msg)
 	-- Check for Mana Buildup removal
 	if string.find(msg, L["trigger_remove_mana_buildup"]) then
 		self:RemoveBar(L["bar_mana_buildup"])
-		self:Message(L["msg_mana_buildup_remove"], "Green", nil)
+		self:Message(L["msg_mana_buildup_remove"], "Positive", true, "Long")
 	end
 end
 
@@ -449,13 +449,13 @@ function module:BigWigs_RecvSync(sync, rest, nick)
 	elseif sync == syncName.mana_buildup then
 		if self.db.profile.mana_buildup and rest == UnitName("player") then
 			self:Bar(L["bar_mana_buildup"], timer.mana_buildup, icon.mana_buildup)
-			self:Message(L["msg_mana_buildup_you"], "Urgent", nil, "Info")
+			self:Message(L["msg_mana_buildup_you"], "Urgent", true, "Info")
 		elseif self.db.profile.mana_buildup then
 			self:Message(string.format(L["msg_mana_buildup"], rest), "Attention", nil, "Info")
 		end
 	elseif sync == syncName.unstable_mana then
 		if self.db.profile.unstable_mana and rest == UnitName("player") then
-			self:Message(L["msg_unstable_mana_you"], "Urgent", nil, "Info")
+			self:Message(L["msg_unstable_mana_you"], "Urgent", true, "Info")
 			self:Bar(L["bar_unstable_mana"], timer.unstable_mana, icon.unstable_mana)
 		elseif self.db.profile.unstable_mana then
 			self:Message(string.format(L["msg_unstable_mana"], rest), "Attention", nil, "Info")
@@ -479,7 +479,7 @@ function module:BigWigs_RecvSync(sync, rest, nick)
 		end
 	elseif sync == syncName.astrologist_rain then
 		if self.db.profile.astrologist_rain then
-			self:Message(L["msg_astrologist_rain"], "Important")
+			self:Message(L["msg_astrologist_rain"], "Important", nil, false)
 			self:WarningSign(icon.astrologist_rain, 2, false, L["warn_astrologist_rain"])
 			if playerClass == "PRIEST" then
 				self:Sound("Beware")
@@ -510,7 +510,7 @@ end
 function module:EnvelopedFlames(player)
 	if self.db.profile.magus_flames then
 		if player == UnitName("player") then
-			self:Message(L["msg_magus_flames_self"], "Important", nil, "Beware")
+			self:Message(L["msg_magus_flames_self"], "Important", true, "Beware")
 			self:RemoveWarningSign(icon.astrologist_insight, true) --cancel other forced sign since this is more important
 			self:WarningSign(icon.magus_flames, 3, true, L["warn_magus_flames"])
 		elseif playerClass == "PALADIN" or playerClass == "PRIEST" then

--- a/Raids/KarazhanUpper/KeeperGnarlmoon.lua
+++ b/Raids/KarazhanUpper/KeeperGnarlmoon.lua
@@ -18,8 +18,6 @@ module.defaultDB = {
 	owlphase = true,
 	owlenrage = true,
 	owlhpframe = true,
-	owlframeposx = 100,
-	owlframeposy = 400,
 	owlgaze = true,
 	printkeeper = false,
 }
@@ -58,8 +56,8 @@ L:RegisterTranslations("enUS", function()
 		owlenrage_desc = "Warns when the Owls are about to enrage",
 
 		owlhpframe_cmd = "owlhpframe",
-		owlhpframe_name = "Owl HP Frame",
-		owlhpframe_desc = "Shows a frame with the owl HP during owl phases",
+		owlhpframe_name = "Owl HP Bars",
+		owlhpframe_desc = "Shows HP bars during owl phases",
 
 		owlgaze_cmd = "owlgaze",
 		owlgaze_name = "Owl Gaze Alert",
@@ -69,11 +67,6 @@ L:RegisterTranslations("enUS", function()
 		printkeeper_name = "Troubleshoot Info",
 		printkeeper_desc = "Print information to your main chat window: Owl kill time stamps",
 
-
-		lowRedOwl = "Low Red Owl",
-		lowBlueOwl = "Low Blue Owl",
-		highRedOwl = "High Red Owl",
-		highBlueOwl = "High Blue Owl",
 
 		trigger_lunarShiftCast = "Keeper Gnarlmoon begins to perform Lunar Shift",
 		bar_lunarShiftCast = "Lunar Shift Casting!",
@@ -89,8 +82,14 @@ L:RegisterTranslations("enUS", function()
 		trigger_owlPhaseStart = "Keeper Gnarlmoon gains Worgen Dimension",
 		trigger_owlKill = "Owl dies.", --CHAT_MSG_COMBAT_HOSTILE_DEATH
 		trigger_owlPhaseEnd = "Worgen Dimension fades from Keeper Gnarlmoon",
-		msg_owlPhaseStart = "Owl Phase begins - kill the owls at the same time within 1 min!",
+		msg_owlPhaseStart = "Owl Phase - kill at the same time",
 		msg_owlPhaseEnd = "Owl Phase ended!",
+		unit_owlBlue = "Blue Owl",
+		unit_owlRed = "Red Owl",
+		bar_owlBlueClose = "Blue Front",
+		bar_owlBlueFar = "Blue Back",
+		bar_owlRedClose = "Red Front",
+		bar_owlRedFar = "Red Back",
 
 		bar_owlEnrage = "Owls Enrage",
 		msg_owlEnrage = "Owls will enrage in 10 seconds!",
@@ -133,14 +132,17 @@ local icon = {
 	blueMoon = "inv_ore_arcanite_02",
 	bloodBoil = "Spell_Shadow_BloodBoil",
 	ravens = "Ability_Hunter_Pet_Bat",
+	owl = "Ability_Hunter_Pet_Owl",
 }
 
 local color = {
 	lunarShift = "Blue",
 	owlPhase = "Green",
-	owlEnrage = "Red",
+	owlEnrage = "Orange",
 	bloodBoil = "Red",
 	ravens = "Black",
+	owlRed = "ff4444",
+	owlBlue = "2277ff",
 }
 
 local syncName = {
@@ -156,22 +158,13 @@ local spellIds = {
 	ravens = 51083, -- Flock of Ravens
 }
 
-function module:OnSetup()
-	self.started = nil
-
-	-- Used to monitor when owl phase will begin
-	self.lowHp = nil
-	self.midHp = nil
-	self.gnarlHealth = 100
-
-	-- Reset owl health values
-	self.lowRedOwlHp = 100
-	self.lowBlueOwlHp = 100
-	self.highRedOwlHp = 100
-	self.highBlueOwlHp = 100
-
-	self.owlsExist = false
-end
+local guid = {
+	gnarlmoon = "0xF13000F1F3276A33",
+	owlRedClose = nil,
+	owlRedFar = nil,
+	owlBlueClose = nil,
+	owlBlueFar = nil,
+}
 
 function module:OnEnable()
 	self:RegisterEvent("CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE")
@@ -191,33 +184,20 @@ function module:OnEnable()
 		self:RegisterCastEventsForUnitName("Keeper Gnarlmoon", "GnarlmoonCastEvent")
 	end
 
-	-- Store owl health
-	self.lowRedOwlHp = 100
-	self.lowBlueOwlHp = 100
-	self.highRedOwlHp = 100
-	self.highBlueOwlHp = 100
-
-	-- Create the owl status frame but keep it hidden until needed
-	if self.db.profile.owlhpframe then
-		self:UpdateOwlStatusFrame()
-		self.owlStatusFrame:Show() -- let people position before fight
-	end
+	-- enable custom colors
+	BigWigsColors:RegHex(color.owlRed)
+	BigWigsColors:RegHex(color.owlBlue)
 end
 
-function module:OnEngage()
-	if self.owlStatusFrame then
-		self.owlStatusFrame:Hide()
-	end
+function module:OnSetup()	
+	self.started = nil
 
-	-- Used to monitor when owl phase will begin
 	self.lowHp = nil
 	self.midHp = nil
 	self.gnarlHealth = 100
+end
 
-	-- Make sure the owl frame is hidden at the start of the encounter
-	self.owlsExist = false
-	self:UpdateOwlStatusFrame()
-
+function module:OnEngage()
 	if self.db.profile.lunarshift then
 		self:Bar(L["bar_lunarShiftCD"], timer.lunarShiftCD, icon.lunarShift, true, color.lunarShift)
 	end
@@ -226,19 +206,18 @@ function module:OnEngage()
 		self:Bar(L["bar_ravens"], timer.ravenSummon[1], icon.ravens, true, color.ravens)
 	end
 	if self.db.profile.ravens then
-		self:DelayedMessage(timer.ravenSummon[1] - 5, L["msg_ravensSoon"], "Important", false, nil, false)
+		self:DelayedMessage(timer.ravenSummon[1] - 5, L["msg_ravensSoon"], "Important")
 	end
 
+	self.lowHp = nil
+	self.midHp = nil
+	self.gnarlHealth = 100
 	self:ScheduleRepeatingEvent("CheckHps", self.CheckHps, 1, self)
 end
 
 function module:OnDisengage()
-	if self:IsEventScheduled("CheckHps") then
-		self:CancelScheduledEvent("CheckHps")
-	end
-
-	self.owlsExist = false
-	self:UpdateOwlStatusFrame()
+	self:CancelScheduledEvent("CheckHps")
+	self:StopMonitoringOwls()
 end
 
 function module:CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE(msg)
@@ -337,7 +316,7 @@ function module:Ravens()
 		self:Bar(L["bar_ravens"], timer.ravenSummon[2], icon.ravens, true, color.ravens)
 	end
 	if self.db.profile.ravens then
-		self:DelayedMessage(timer.ravenSummon[2] - 5, L["msg_ravensSoon"], "Important", false, nil, false)
+		self:DelayedMessage(timer.ravenSummon[2] - 5, L["msg_ravensSoon"], "Important")
 	end
 end
 
@@ -345,15 +324,9 @@ function module:OwlPhaseStart()
 	if self.db.profile.printkeeper then
 		print("Start of Owl Phase")
 	end
-	-- set owl hps to 100
-	self.lowRedOwlHp = 100
-	self.lowBlueOwlHp = 100
-	self.highRedOwlHp = 100
-	self.highBlueOwlHp = 100
 	
 	if self.db.profile.owlphase then		
-		self:Message(L["msg_owlPhaseStart"], "Attention")
-		self:Sound("Alarm")
+		self:Message(L["msg_owlPhaseStart"], "Attention", nil, "Alarm")
 	end
 
 	if self.db.profile.owlenrage then
@@ -370,8 +343,7 @@ function module:OwlPhaseStart()
 	self:RemoveBar(L["bar_bloodBoil"])
 
 	if self.db.profile.owlhpframe then
-		self.owlsExist = true
-		self:UpdateOwlStatusFrame()
+		self:FindOwls()
 	end
 end
 
@@ -392,7 +364,7 @@ end
 
 function module:OwlPhaseEnd()
 	if self.db.profile.owlphase then
-		self:Message(L["msg_owlPhaseEnd"], "Positive")
+		self:Message(L["msg_owlPhaseEnd"], "Positive", nil, "Long")
 	end
 
 	local enrageBar, time, elapsed = self:BarStatus(L["bar_owlEnrage"])
@@ -406,265 +378,72 @@ function module:OwlPhaseEnd()
 		self:RemoveBar(L["bar_owlEnrage"])
 	end
 
-	self.owlsExist = false
-	self:UpdateOwlStatusFrame()
+	self:StopMonitoringOwls()
 end
 
 function module:CheckHps()
-	-- For tracking owl health
-	local lowestRedOwlHp = 100
-	local lowestBlueOwlHp = 100
-	local highestRedOwlHp = 0
-	local highestBlueOwlHp = 0
-
-	for i = 1, GetNumRaidMembers() do
-		local targetString = "raid" .. i .. "target"
-		local targetName = UnitName(targetString)
-
-		if targetName == module.translatedName then
-			-- Check Gnarlmoon's health
-			local tempH = UnitHealth(targetString)
-			if tempH > 0 then
-				local tempM = UnitHealthMax(targetString)
-				if tempM and tempM > 0 then
-					local health = tempH / tempM * 100
-					if health < 100 then
-						self.gnarlHealth = health
-					end
-				end
-			end
-		elseif self.owlsExist and targetName and string.find(targetName, "Owl") then
-			-- Calculate owl health percentage
-			local owlHealth = 100
-			local h = UnitHealth(targetString)
-			local m = UnitHealthMax(targetString)
-
-			if h and m and m > 0 then
-				owlHealth = math.floor((h / m) * 100)
-			end
-
-			-- Check owl name to determine type and track lowest health
-			if string.find(targetName, "Red") then
-				if owlHealth < lowestRedOwlHp then
-					lowestRedOwlHp = owlHealth
-				end
-				if owlHealth > highestRedOwlHp then
-					highestRedOwlHp = owlHealth
-				end
-			elseif string.find(targetName, "Blue") then
-				if owlHealth < lowestBlueOwlHp then
-					lowestBlueOwlHp = owlHealth
-				end
-				if owlHealth > highestBlueOwlHp then
-					highestBlueOwlHp = owlHealth
-				end
-			end
-		end
-	end
-
-	-- During test function, don't reset owl health
-	if self.owlsExist and not self.testInProgress then
-		-- Only update if the new health is lower than current health
-		if lowestRedOwlHp < 100 then
-			self.lowRedOwlHp = lowestRedOwlHp
-		end
-
-		if lowestBlueOwlHp < 100 then
-			self.lowBlueOwlHp = lowestBlueOwlHp
-		end
-
-		if highestRedOwlHp > 0 then
-			self.highRedOwlHp = highestRedOwlHp
-		end
-
-		if highestBlueOwlHp > 0 then
-			self.highBlueOwlHp = highestBlueOwlHp
-		end
-	end
-
-	if self.owlsExist then
-		self:UpdateOwlStatusFrame()
+	local percent = BigWigs:GetHealthPercent(guid.gnarlmoon)
+	if percent then
+		self.gnarlHealth = percent
 	end
 
 	-- Handle Gnarlmoon's health thresholds for phase warnings
 	if self.gnarlHealth < 71 and self.midHp == nil then
 		self.midHp = true
-		self:Message(L["msg_midHp"], "Urgent", true, nil, false)
-		self:Sound("Info")
+		self:Message(L["msg_midHp"], "Urgent", true, "Info")
 	end
 
 	if self.gnarlHealth < 38 and self.lowHp == nil then
 		self.lowHp = true
-		self:Message(L["msg_lowHp"], "Urgent", true, nil, false)
-		self:Sound("Info")
+		self:Message(L["msg_lowHp"], "Urgent", true, "Info")
+		self:CancelScheduledEvent("CheckHps")
 	end
 end
 
-function module:UpdateOwlStatusFrame()
-	if not self.db.profile.owlhpframe then
-		return
-	end
-
-	-- Create frame if needed
-	if not self.owlStatusFrame then
-		self.owlStatusFrame = CreateFrame("Frame", "GnarlmoonOwlStatusFrame", UIParent)
-		self.owlStatusFrame.module = self
-		self.owlStatusFrame:SetWidth(200)  -- Wider to fit columns
-		self.owlStatusFrame:SetHeight(90)  -- Increased height for more padding
-		self.owlStatusFrame:ClearAllPoints()
-		local s = self.owlStatusFrame:GetEffectiveScale()
-		self.owlStatusFrame:SetPoint("TOPLEFT", UIParent, "BOTTOMLEFT", (self.db.profile.owlframeposx or 100) / s, (self.db.profile.owlframeposy or 400) / s)
-		self.owlStatusFrame:SetBackdrop({
-			bgFile = "Interface\\DialogFrame\\UI-DialogBox-Background",
-			edgeFile = "Interface\\DialogFrame\\UI-DialogBox-Border",
-			tile = true,
-			tileSize = 16,
-			edgeSize = 16,
-			insets = { left = 8, right = 8, top = 8, bottom = 8 }
-		})
-		self.owlStatusFrame:SetBackdropColor(0, 0, 0, 1)
-
-		-- Allow dragging
-		self.owlStatusFrame:SetMovable(true)
-		self.owlStatusFrame:EnableMouse(true)
-		self.owlStatusFrame:RegisterForDrag("LeftButton")
-		self.owlStatusFrame:SetScript("OnDragStart", function()
-			this:StartMoving()
-		end)
-		self.owlStatusFrame:SetScript("OnDragStop", function()
-			this:StopMovingOrSizing()
-
-			local scale = this:GetEffectiveScale()
-			this.module.db.profile.owlframeposx = this:GetLeft() * scale
-			this.module.db.profile.owlframeposy = this:GetTop() * scale
-		end)
-
-		local font = "Fonts\\FRIZQT__.TTF"
-		local fontSize = 12
-
-		-- Frame title
-		self.owlStatusFrame.title = self.owlStatusFrame:CreateFontString(nil, "ARTWORK")
-		self.owlStatusFrame.title:SetFontObject(GameFontNormal)
-		self.owlStatusFrame.title:SetPoint("TOP", self.owlStatusFrame, "TOP", 0, -10)
-		self.owlStatusFrame.title:SetText("Owl HP")
-		self.owlStatusFrame.title:SetFont(font, fontSize)
-
-		-- Red Column Header (Left Side)
-		self.owlStatusFrame.redHeader = self.owlStatusFrame:CreateFontString(nil, "ARTWORK")
-		self.owlStatusFrame.redHeader:SetFontObject(GameFontNormal)
-		self.owlStatusFrame.redHeader:SetPoint("TOPLEFT", self.owlStatusFrame, "TOPLEFT", 15, -25)
-		self.owlStatusFrame.redHeader:SetText("Red")
-		self.owlStatusFrame.redHeader:SetFont(font, fontSize)
-		self.owlStatusFrame.redHeader:SetTextColor(1, 0.3, 0.3)
-
-		-- Blue Column Header (Right Side)
-		self.owlStatusFrame.blueHeader = self.owlStatusFrame:CreateFontString(nil, "ARTWORK")
-		self.owlStatusFrame.blueHeader:SetFontObject(GameFontNormal)
-		self.owlStatusFrame.blueHeader:SetPoint("TOPRIGHT", self.owlStatusFrame, "TOPRIGHT", -15, -25)
-		self.owlStatusFrame.blueHeader:SetText("Blue")
-		self.owlStatusFrame.blueHeader:SetFont(font, fontSize)
-		self.owlStatusFrame.blueHeader:SetTextColor(0.3, 0.3, 1)
-
-		-- Create invisible anchor frames for precise alignment
-		local leftAnchor = CreateFrame("Frame", nil, self.owlStatusFrame)
-		leftAnchor:SetPoint("CENTER", self.owlStatusFrame, "CENTER", -60, 0)
-		leftAnchor:SetWidth(1)
-		leftAnchor:SetHeight(1)
-
-		local rightAnchor = CreateFrame("Frame", nil, self.owlStatusFrame)
-		rightAnchor:SetPoint("CENTER", self.owlStatusFrame, "CENTER", 60, 0)
-		rightAnchor:SetWidth(1)
-		rightAnchor:SetHeight(1)
-
-		-- Low Owls Row Label
-		self.owlStatusFrame.lowLabel = self.owlStatusFrame:CreateFontString(nil, "ARTWORK")
-		self.owlStatusFrame.lowLabel:SetFontObject(GameFontNormal)
-		self.owlStatusFrame.lowLabel:SetPoint("CENTER", self.owlStatusFrame, "CENTER", 0, -10)
-		self.owlStatusFrame.lowLabel:SetText("Low")
-		self.owlStatusFrame.lowLabel:SetFont(font, fontSize)
-
-		-- High Owls Row Label
-		self.owlStatusFrame.highLabel = self.owlStatusFrame:CreateFontString(nil, "ARTWORK")
-		self.owlStatusFrame.highLabel:SetFontObject(GameFontNormal)
-		self.owlStatusFrame.highLabel:SetPoint("CENTER", self.owlStatusFrame, "CENTER", 0, -30)
-		self.owlStatusFrame.highLabel:SetText("High")
-		self.owlStatusFrame.highLabel:SetFont(font, fontSize)
-
-		-- Red Low Owl HP (left column)
-		self.owlStatusFrame.lowRedOwlHp = self.owlStatusFrame:CreateFontString(nil, "ARTWORK")
-		self.owlStatusFrame.lowRedOwlHp:SetFontObject(GameFontNormal)
-		self.owlStatusFrame.lowRedOwlHp:SetPoint("CENTER", leftAnchor, "CENTER", 0, -10)
-		self.owlStatusFrame.lowRedOwlHp:SetJustifyH("CENTER")
-		self.owlStatusFrame.lowRedOwlHp:SetFont(font, fontSize)
-		self.owlStatusFrame.lowRedOwlHp:SetTextColor(1, 0.3, 0.3)
-
-		-- Blue Low Owl HP (right column)
-		self.owlStatusFrame.lowBlueOwlHp = self.owlStatusFrame:CreateFontString(nil, "ARTWORK")
-		self.owlStatusFrame.lowBlueOwlHp:SetFontObject(GameFontNormal)
-		self.owlStatusFrame.lowBlueOwlHp:SetPoint("CENTER", rightAnchor, "CENTER", 0, -10)
-		self.owlStatusFrame.lowBlueOwlHp:SetJustifyH("CENTER")
-		self.owlStatusFrame.lowBlueOwlHp:SetFont(font, fontSize)
-		self.owlStatusFrame.lowBlueOwlHp:SetTextColor(0.3, 0.3, 1)
-
-		-- Red High Owl HP (left column)
-		self.owlStatusFrame.highRedOwlHp = self.owlStatusFrame:CreateFontString(nil, "ARTWORK")
-		self.owlStatusFrame.highRedOwlHp:SetFontObject(GameFontNormal)
-		self.owlStatusFrame.highRedOwlHp:SetPoint("CENTER", leftAnchor, "CENTER", 0, -30)
-		self.owlStatusFrame.highRedOwlHp:SetJustifyH("CENTER")
-		self.owlStatusFrame.highRedOwlHp:SetFont(font, fontSize)
-		self.owlStatusFrame.highRedOwlHp:SetTextColor(1, 0.3, 0.3)
-
-		-- Blue High Owl HP (right column)
-		self.owlStatusFrame.highBlueOwlHp = self.owlStatusFrame:CreateFontString(nil, "ARTWORK")
-		self.owlStatusFrame.highBlueOwlHp:SetFontObject(GameFontNormal)
-		self.owlStatusFrame.highBlueOwlHp:SetPoint("CENTER", rightAnchor, "CENTER", 0, -30)
-		self.owlStatusFrame.highBlueOwlHp:SetJustifyH("CENTER")
-		self.owlStatusFrame.highBlueOwlHp:SetFont(font, fontSize)
-		self.owlStatusFrame.highBlueOwlHp:SetTextColor(0.3, 0.3, 1)
-	end
-
-	-- Show/hide frame based on whether owls exist
-	if self.owlsExist then
-		self.owlStatusFrame:Show()
+function module:FindOwls()
+	local anyBlue = BigWigs:GetGUIDByName(L["unit_owlBlue"], 1)
+	if anyBlue then
+		local plusOne = BigWigs:OffsetGUID(anyBlue, 1)
+		if UnitExists(plusOne) and UnitName(plusOne) == L["unit_owlBlue"] then
+			guid.owlRedClose = BigWigs:OffsetGUID(anyBlue, -16777214)
+			guid.owlRedFar = BigWigs:OffsetGUID(anyBlue, -16777213)
+			guid.owlBlueClose = anyBlue
+			guid.owlBlueFar = plusOne
+			self:StartOwlMonitorBars()
+		else
+			guid.owlRedClose = BigWigs:OffsetGUID(anyBlue, -16777215)
+			guid.owlRedFar = BigWigs:OffsetGUID(anyBlue, -16777214)
+			guid.owlBlueClose = BigWigs:OffsetGUID(anyBlue, -1)
+			guid.owlBlueFar = anyBlue
+			self:StartOwlMonitorBars()
+		end
 	else
-		self.owlStatusFrame:Hide()
-		return
+		self:ScheduleEvent("GnarlmoonFindOwls", self.FindOwls, 0.2, self)
 	end
-
-	-- Update HP values
-	self:SetOwlHpText(self.owlStatusFrame.lowBlueOwlHp, self.lowBlueOwlHp)
-	self:SetOwlHpText(self.owlStatusFrame.lowRedOwlHp, self.lowRedOwlHp)
-	self:SetOwlHpText(self.owlStatusFrame.highBlueOwlHp, self.highBlueOwlHp)
-	self:SetOwlHpText(self.owlStatusFrame.highRedOwlHp, self.highRedOwlHp)
 end
 
-function module:SetOwlHpText(fontString, healthPercent)
-	if not fontString then
-		return
-	end
-
-	-- Format health percentage string
-	local text = healthPercent .. "%"
-
-	-- Color based on health percentage
-	local r, g, b = 1, 1, 1
-	if healthPercent <= 0 then
-		text = "DEAD"
-		r, g, b = 0.5, 0.5, 0.5
-	elseif healthPercent < 15 then
-		r, g, b = 1, 1, 0
-	end
-
-	-- Set the text and color
-	fontString:SetText(text)
-	fontString:SetTextColor(r, g, b)
+function module:StartOwlMonitorBars()
+	self:MonitorBar(L["bar_owlBlueClose"], icon.owl, guid.owlBlueClose, "health", false, false, false, true, color.owlBlue)
+	self:MonitorBar(L["bar_owlBlueFar"], icon.owl, guid.owlBlueFar, "health", false, false, false, true, color.owlBlue)
+	self:MonitorBar(L["bar_owlRedClose"], icon.owl, guid.owlRedClose, "health", false, false, false, true, color.owlRed)
+	self:MonitorBar(L["bar_owlRedFar"], icon.owl, guid.owlRedFar, "health", false, false, false, true, color.owlRed)
 end
 
--- Update the Test function to include Blood Boil events:
+function module:StopMonitoringOwls()
+	self:CancelScheduledEvent("GnarlmoonFindOwls")
+	self:RemoveBar(L["bar_owlBlueClose"])
+	self:RemoveBar(L["bar_owlBlueFar"])
+	self:RemoveBar(L["bar_owlRedClose"])
+	self:RemoveBar(L["bar_owlRedFar"])
+	guid.owlBlueClose = nil
+	guid.owlBlueFar = nil
+	guid.owlRedClose = nil
+	guid.owlRedFar = nil
+end
+
 function module:Test()
 	-- Initialize module state
-	self:OnSetup()
-	self:OnEnable()
+	self:Engage()
 
 	-- Flag to prevent resetting owl health during test
 	self.testInProgress = true
@@ -685,7 +464,7 @@ function module:Test()
 		-- Initial Lunar Shift
 		{ time = 10, func = function()
 			print("Test: Keeper Gnarlmoon begins to cast Lunar Shift")
-			module:CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE("Keeper Gnarlmoon begins to cast Lunar Shift.")
+			module:CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE("Keeper Gnarlmoon begins to perform Lunar Shift.")
 		end },
 
 		-- Second Blood Boil
@@ -710,7 +489,7 @@ function module:Test()
 		-- Second Lunar Shift
 		{ time = 21, func = function()
 			print("Test: Keeper Gnarlmoon begins to cast Lunar Shift")
-			module:CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE("Keeper Gnarlmoon begins to cast Lunar Shift.")
+			module:CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE("Keeper Gnarlmoon begins to perform Lunar Shift.")
 		end },
 
 		-- First Owl Phase (at 66.66% HP)
@@ -723,34 +502,16 @@ function module:Test()
 		{ time = 25, func = function()
 			print("Test: You are afflicted by Red Moon")
 			module:CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE("You are afflicted by Red Moon.")
-
-			module.lowRedOwlHp = 85
-			module.lowBlueOwlHp = 70
-			module.highRedOwlHp = 90
-			module.highBlueOwlHp = 75
-			module:UpdateOwlStatusFrame()
 		end },
 
 		{ time = 31, func = function()
 			print("Test: You are afflicted by Owl Gaze")
 			module:CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE("You are afflicted by Owl Gaze.")
-			
-			module.lowRedOwlHp = 50
-			module.lowBlueOwlHp = 45
-			module.highRedOwlHp = 55
-			module.highBlueOwlHp = 48
-			module:UpdateOwlStatusFrame()
 		end },
 
 		{ time = 33, func = function()
 			print("Test: You are afflicted by Blue Moon")
 			module:CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE("You are afflicted by Blue Moon.")
-
-			module.lowRedOwlHp = 15
-			module.lowBlueOwlHp = 12
-			module.highRedOwlHp = 18
-			module.highBlueOwlHp = 13
-			module:UpdateOwlStatusFrame()
 		end },
 
 		-- Owl Phase ends
@@ -762,7 +523,7 @@ function module:Test()
 		-- Third Lunar Shift
 		{ time = 40, func = function()
 			print("Test: Keeper Gnarlmoon begins to cast Lunar Shift")
-			module:CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE("Keeper Gnarlmoon begins to cast Lunar Shift.")
+			module:CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE("Keeper Gnarlmoon begins to perform Lunar Shift.")
 		end },
 
 		-- HP triggers for second owl phase
@@ -782,12 +543,6 @@ function module:Test()
 		{ time = 52, func = function()
 			print("Test: You are afflicted by Blue Moon")
 			module:CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE("You are afflicted by Blue Moon.")
-
-			module.lowRedOwlHp = 60
-			module.lowBlueOwlHp = 85
-			module.highRedOwlHp = 75
-			module.highBlueOwlHp = 90
-			module:UpdateOwlStatusFrame()
 		end },
 
 		-- Second Flock of Ravens (35s after first)
@@ -798,11 +553,6 @@ function module:Test()
 
 		{ time = 58, func = function()
 			print("Test: Red Owl dies.")
-			module.lowRedOwlHp = 0
-			module.lowBlueOwlHp = 45
-			module.highRedOwlHp = 42
-			module.highBlueOwlHp = 50
-			module:UpdateOwlStatusFrame()
 			module:CHAT_MSG_COMBAT_HOSTILE_DEATH("Red Owl dies.")
 		end },
 
@@ -820,7 +570,7 @@ function module:Test()
 		-- Final Lunar Shift
 		{ time = 75, func = function()
 			print("Test: Keeper Gnarlmoon begins to cast Lunar Shift")
-			module:CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE("Keeper Gnarlmoon begins to cast Lunar Shift.")
+			module:CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE("Keeper Gnarlmoon begins to perform Lunar Shift.")
 		end },
 
 		-- End test
@@ -840,4 +590,4 @@ function module:Test()
 	return true
 end
 
--- Usage: /run local m=BigWigs:GetModule("Keeper Gnarlmoon"); BigWigs:SetupModule("Keeper Gnarlmoon");m:Test();
+-- Usage: /run BigWigs:GetModule("Keeper Gnarlmoon"):Test();

--- a/Raids/KarazhanUpper/Mephistroth.lua
+++ b/Raids/KarazhanUpper/Mephistroth.lua
@@ -331,7 +331,7 @@ function module:OnEnemyDeath(msg)
 			fail_shards = 6
 			self:Sync(syncName.shardsChannelEnd)
 		elseif self.db.profile.shardscount then
-			self:Message(fail_shards..L.msg_shardsRemaining, "Positive")
+			self:Message(fail_shards..L.msg_shardsRemaining, "Positive", true, false)
 		end
 	end
 end
@@ -384,7 +384,7 @@ function module:EnemyBuffEvent(msg)
 	-- Unfathomed Hatred (shard fail)
 	if string.find(msg, L.trigger_shardsFail) then
 		if self.db.profile.shardschannel then
-			self:Message(L.msg_shardsFail, "Important", true, "Alert")
+			self:Message(L.msg_shardsFail, "Important", nil, "Alert")
 		end
 	end
 end
@@ -443,7 +443,7 @@ function module:BigWigs_RecvSync(sync, rest, nick)
 	elseif sync == syncName.shardsChannelEnd then
 		self:RemoveBar(L.bar_shardsChannel)
 		if self.db.profile.shardschannel then
-			self:Message(L.msg_shardsOver, "Positive", true, "Long")
+			self:Message(L.msg_shardsOver, "Positive", nil, "Long")
 		end
 
 	elseif sync == syncName.doomGain and rest then
@@ -509,7 +509,7 @@ function module:ShackleShatter(player)
 	end
 	player = player == UnitName("player") and "You" or player
 	local message = player .. L.msg_shackleShatter
-	self:Message(message, "Important", false, nil, false)
+	self:Message(message, "Important", nil, "Alert")
 	print(message)
 end
 
@@ -579,7 +579,7 @@ function module:NathrezimTerror()
 	self:RemoveBar(L.bar_fearCD)
 
 	if self.db.profile.fearcast then
-		self:Message(L.msg_fearCast, "Core")
+		self:Message(L.msg_fearCast, "Core", nil, false)
 		self:Bar(L.bar_fearCast, timer.fearCast, icon.fear, true, "Cyan")
 	end
 	if self.db.profile.fearcd then

--- a/Raids/KarazhanUpper/Rupturan.lua
+++ b/Raids/KarazhanUpper/Rupturan.lua
@@ -1,8 +1,8 @@
 local module, L = BigWigs:ModuleDeclaration("Rupturan the Broken", "Karazhan")
 
-module.revision = 30004
+module.revision = 30005
 module.enabletrigger = module.translatedName
-module.toggleoptions = { "boulderalert", "bouldermark", "bouldersay", "livingstone", "opportunity", -1, "igniteearth", "dirtmound", "dirtmoundmark", -1, "flamestrike", "flamestrikemove", "felheartalert", "felheartbar", "reform", "bosskill" }
+module.toggleoptions = { "boulderalert", "bouldermark", "bouldersay", "livingstone", "opportunity", -1, "igniteearth", "dirtmound", "dirtmoundmark", -1, "flamestrike", "flamestrikemove", "felheartalert", "felheartbar", "fragmentbars", "reform", "bosskill" }
 module.zonename = {
 	AceLibrary("AceLocale-2.2"):new("BigWigs")["Tower of Karazhan"],
 	AceLibrary("Babble-Zone-2.2")["Tower of Karazhan"],
@@ -11,6 +11,7 @@ module.zonename = {
 }
 
 local _, playerClass = UnitClass("player")
+local opportunityThreshold = 25
 
 module.defaultDB = {
 	boulderalert = false,
@@ -25,6 +26,7 @@ module.defaultDB = {
 	flamestrikemove = true,
 	felheartalert = true,
 	felheartbar = playerClass == "HUNTER" or playerClass == "PRIEST" or playerClass == "WARLOCK",
+	fragmentbars = true,
 	reform = true,
 }
 
@@ -53,7 +55,7 @@ L:RegisterTranslations("enUS", function() return {
 
 	opportunity_cmd = "opportunity",
 	opportunity_name = "Window of Opportunity",
-	opportunity_desc = "Warns about remaining or incoming Living Stones below 10% boss HP to avoid Explode mechanic (when the boss dies the remaining Living Stones detonate)",
+	opportunity_desc = "Warns about remaining or incoming Living Stones below "..opportunityThreshold.."% boss HP to avoid Explode mechanic (when the boss dies the remaining Living Stones detonate)",
 
 	igniteearth_cmd  = "igniteearth",
 	igniteearth_name = "Ignite Earth",
@@ -83,6 +85,10 @@ L:RegisterTranslations("enUS", function() return {
 	felheartbar_name = "Felheart Mana Bar",
 	felheartbar_desc = "Adds a continuously updating mana bar for Felheart.",
 
+	fragmentbars_cmd = "fragmentbars",
+	fragmentbars_name = "Fragment Health Bars",
+	fragmentbars_desc = "Show health bars for all 3 fragments in Phase 2.",
+
 	reform_cmd = "reform",
 	reform_name = "Reform Timer",
 	reform_desc = "When you kill a Fragment, show show time left until Rupturan will be reformed.",
@@ -107,12 +113,14 @@ L:RegisterTranslations("enUS", function() return {
 	msg_windowClosing    = "Stone incoming!",
 	msg_windowClosed     = "Stone alive! DON'T kill Rupturan",
 	msg_felheartMana     = "Felheart at %s%% mana!",
+	bar_fragment	     = "Frag",
 
 	-- Triggers
 	trigger_start        = "All shall crumble",
 	trigger_phase2       = "Let the cracks of this world destroy you",
 	trigger_boss_dead    = "Perished... To dust",
 	unit_felheart        = "Felheart",
+	unit_fragment        = "Fragment of Rupturan",
 
 	trigger_tb_cast      = "Rupturan the Broken begins to perform Throw Boulder",
 	trigger_tb_hit       = "Rupturan the Broken's Throw Boulder hits (.+) for",
@@ -148,6 +156,7 @@ local icon = {
 	reform		= "Spell_Nature_AstralRecalGroup",
 	window		= "INV_Misc_PocketWatch_01",
 	felheart	= "Spell_Holy_PrayerOfFortitude",
+	fragment	= "Spell_Nature_StrengthOfEarthTotem02",
 }
 
 local syncName = {
@@ -172,6 +181,9 @@ local spellIds = {
 local guid = {
 	rupturan = "0xF13000EA39073D35",
 	felheart = nil,
+	fragmentA = nil,
+	fragmentB = nil,
+	fragmentC = nil,
 }
 
 -- keep track of players to later reset raid marks, and active Living Stones
@@ -231,6 +243,7 @@ function module:OnEngage()
 	last_boulder = 0
 	active_living_stones = 0
 	last_mana_warn = 0
+	self:RemoveFragmentBars()
 end
 
 function module:OnDisengage()
@@ -238,10 +251,12 @@ function module:OnDisengage()
 	self:RemoveBar(L.bar_ls_earthstomp)
 	self:CancelDelayedBar(L.bar_ignite_earth_CD)
 	self:RemoveBar(L.bar_ignite_earth_CD)
+	self:RemoveFragmentBars()
 	self:RestorePreviousRaidTargetForPlayer(mound_chasing)
 	self:RestorePreviousRaidTargetForPlayer(boulder_victim)
 	self:CancelScheduledEvent("RupturanFindFelheart")
 	self:CancelScheduledEvent("RupturanCheckFelheart")
+	self:CancelScheduledEvent("RupturanFindFragments")
 end
 
 -------------------------------------------------------------------------------
@@ -274,6 +289,14 @@ function module:Event(msg)
 	end
 end
 
+function module:LowestFragmentCastTimeCoefficient()
+	local coefficientA = BigWigs:GetCastTimeCoefficient(guid.fragmentA)
+	local coefficientB = BigWigs:GetCastTimeCoefficient(guid.fragmentB)
+	local coefficientC = BigWigs:GetCastTimeCoefficient(guid.fragmentC)
+	
+	return math.min(coefficientA, coefficientB, coefficientC)
+end
+
 function module:UNIT_CASTEVENT(caster,target,action,spellId,castTime)
 	if spellId == spellIds.igniteEarth and action == "START" then
 		self:Sync(syncName.igniteEarth .. " " .. (castTime / 1000))
@@ -284,6 +307,11 @@ function module:UNIT_CASTEVENT(caster,target,action,spellId,castTime)
 		return
 	end
 	if spellId == spellIds.igniteRock and action == "START" then
+		-- check if perhaps other fragments have quicker casts (missing CoT) and sync the lowest cast time to warn about the first Ignite Rock
+		local shortestCast = timer.igniteRock * self:LowestFragmentCastTimeCoefficient() * 1000
+		if castTime > shortestCast then
+			castTime = shortestCast
+		end
 		self:Sync(syncName.igniteRock .. " " .. (castTime / 1000))
 		return
 	end
@@ -296,7 +324,8 @@ end
 function module:SpellEvent(msg)
 	-- non-SuperWoW Ignite Earth cast
 	if string.find(msg, L.trigger_igniteearth) and not SUPERWOW_VERSION then
-		self:Sync(syncName.igniteEarth .. " " .. timer.igniteEarthCast)
+		local castTime = timer.igniteEarthCast * BigWigs:GetCastTimeCoefficient(guid.rupturan)
+		self:Sync(syncName.igniteEarth .. " " .. castTime)
 		return
 	end
 
@@ -334,7 +363,9 @@ function module:SpellEvent(msg)
 
 	-- non-SuperWoW Ignite Rock cast
 	if string.find(msg, L.trigger_igniterock) and not SUPERWOW_VERSION  then
-		self:Sync(syncName.igniteRock .. " " .. timer.igniteRock)
+		-- sync lowest cast time among all Fragments (one might be missing CoT)
+		local castTime = timer.igniteRock * self:LowestFragmentCastTimeCoefficient()
+		self:Sync(syncName.igniteRock .. " " .. castTime)
 		return
 	end
 
@@ -404,7 +435,8 @@ end
 
 function module:IgniteEarth(castTime)
 	if not self.db.profile.igniteearth then return end
-	castTime = castTime or timer.igniteEarthCast
+	
+	castTime = castTime or (timer.igniteEarthCast * BigWigs:GetCastTimeCoefficient(guid.rupturan))
 
 	-- Remove any ongoing CD bar
 	self:CancelDelayedBar(L.bar_ignite_earth_CD)
@@ -420,7 +452,7 @@ end
 function module:DirtMoundQuake()
 	if not self.db.profile.dirtmound then return end
 
-	self:Message(L.msg_dm_quake, "Important", nil, "Alarm")
+	self:Message(L.msg_dm_quake, "Important", true, "Info")
 end
 
 function module:DirtMoundSpawn(player)
@@ -443,8 +475,7 @@ function module:DirtMoundSpawn(player)
 		for i=1,GetNumRaidMembers() do
 			local unit = "raid"..i
 			if UnitName(unit) == player and CheckInteractDistance(unit, 2) then
-				self:Message(format(L.msg_dm_target_near, player), "Important")
-				self:Sound("Alarm")
+				self:Message(format(L.msg_dm_target_near, player), "Important", true, "Alarm")
 				break
 			end
 		end
@@ -459,13 +490,18 @@ function module:Phase2()
 	-- clear popcorn mark
 	self:RestorePreviousRaidTargetForPlayer(mound_chasing)
 	mound_chasing = nil
-	-- start looking for Felheart
+	-- start looking for adds
+	guid.felheart = nil
 	self:FindFelheart()
+	guid.fragmentA = nil
+	guid.fragmentB = nil
+	guid.fragmentC = nil
+	self:FindFragments()
 end
 
 function module:IgniteRock(castTime)
 	if not self.db.profile.flamestrike then return end
-	castTime = castTime or timer.igniteRock
+	castTime = castTime or (timer.igniteRock * self:LowestFragmentCastTimeCoefficient())
 
 	self:Sound("Alarm")
 	self:WarningSign(icon.igniteRock, 3, true, L.warn_ignite_rock)
@@ -494,7 +530,7 @@ function module:ThrowBoulder(targetName)
 		SendChatMessage(L.say_boulder, "SAY")
 	end
 	
-	if self:GetHealth() <= 15 and self.db.profile.opportunity then
+	if self:GetHealth() <= opportunityThreshold and self.db.profile.opportunity then
 		self:Bar(L.bar_window, timer.boulderCast - 0.3, icon.window, true, "White")
 		if not self.db.profile.boulderalert then -- don't double up on messages
 			self:Message(L.msg_windowClosing, "Urgent", true, "Beware")
@@ -505,9 +541,9 @@ end
 function module:ThrowBoulderOutcome(outcome)
 	if outcome == "hit" then
 		active_living_stones = active_living_stones + 1
-		if self:GetHealth() <= 15 and self.db.profile.opportunity then
+		if self:GetHealth() <= opportunityThreshold and self.db.profile.opportunity then
 			self:RemoveBar(L.bar_window)
-			self:Message(L.msg_windowClosed, "Important", true, "Alert")
+			self:Message(L.msg_windowClosed, "Important", nil, "Alert")
 		end
 	end
 
@@ -535,7 +571,7 @@ function module:GetHealth()
 end
 
 function module:CheckOpportunity()
-	if self:GetHealth() > 15 or (not self.db.profile.opportunity) then return end
+	if self:GetHealth() > opportunityThreshold or (not self.db.profile.opportunity) then return end
 
 	local windowHigh = last_boulder + timer.boulderCD[2] + timer.boulderCast - GetTime()
 	if active_living_stones == 0 and windowHigh > 3 then
@@ -563,13 +599,43 @@ function module:CheckFelheart()
 	if self.db.profile.felheartalert and guid.felheart and UnitExists(guid.felheart) then
 		local percent = math.ceil(UnitMana(guid.felheart)/UnitManaMax(guid.felheart) * 100)
 		if percent >= 80 and last_mana_warn + 5 < GetTime() then
-			self:Message(string.format(L.msg_felheartMana, percent), "Core", true, "Beware")
+			self:Message(string.format(L.msg_felheartMana, percent), "Core", nil, "Beware")
 			last_mana_warn = GetTime()
 		end
 	else
 		-- if alert disabled or Felheart doesn't currently exist stop checking
 		self:CancelScheduledEvent("RupturanCheckFelheart")
 	end
+end
+
+function module:FindFragments()
+	local newFragment = BigWigs:GetGUIDByName(L.unit_fragment, 1, {guid.fragmentA, guid.fragmentB, guid.fragmentC}) -- can replace unit name for testing
+	if newFragment then
+		if not guid.fragmentA then
+			guid.fragmentA = newFragment
+		elseif not guid.fragmentB then
+			guid.fragmentB = newFragment
+		elseif not guid.fragmentC then
+			guid.fragmentC = newFragment
+			self:CreateFragmentBars()
+			return
+		end
+	end
+	self:ScheduleEvent("RupturanFindFragments", self.FindFragments, 0.2, self)
+end
+
+function module:CreateFragmentBars()
+	if self.db.profile.fragmentbars then
+		self:MonitorBar("fragmentA", icon.fragment, guid.fragmentA, "health", L.bar_fragment, true)
+		self:MonitorBar("fragmentB", icon.fragment, guid.fragmentB, "health", L.bar_fragment, true)
+		self:MonitorBar("fragmentC", icon.fragment, guid.fragmentC, "health", L.bar_fragment, true)
+	end
+end
+
+function module:RemoveFragmentBars()
+	self:RemoveBar("fragmentA")
+	self:RemoveBar("fragmentB")
+	self:RemoveBar("fragmentC")
 end
 
 -------------------------------------------------------------------------------

--- a/Raids/KarazhanUpper/SanvTasdal.lua
+++ b/Raids/KarazhanUpper/SanvTasdal.lua
@@ -192,7 +192,7 @@ end
 
 function module:CHAT_MSG_SPELL_PERIODIC_CREATURE_BUFFS(msg)
 	if string.find(msg, L["trigger_Enrage"]) then
-		self:Message(L["msg_Enrage"], "Important")
+		self:Message(L["msg_Enrage"], "Important", nil, false)
 		local _, playerClass = UnitClass("player")
 		if playerClass == "HUNTER" then
 			self:Sound("Alert")
@@ -222,7 +222,7 @@ function module:PhaseShifted(player)
 			-- Add personal expiration bar with yellow color
 			self:Bar(L["bar_phaseShiftedExpires"], timer.phaseShiftedDuration, icon.phaseShifted, true, "yellow")
 		else
-			self:Message(string.format(L["msg_phaseShiftedOther"], player), "Urgent")
+			self:Message(string.format(L["msg_phaseShiftedOther"], player), "Urgent", nil, false)
 		end
 	end
 end
@@ -244,7 +244,7 @@ function module:CheckBossHealth()
 		local percent = UnitHealth(guid.sanv)/UnitHealthMax(guid.sanv) * 100
 
 		if percent <= 80 and not self.hitEighty then
-			self:Message(L["msg_portalsOpen"], "Attention", nil, "Alarm")
+			self:Message(L["msg_portalsOpen"], "Attention")
 			self.hitEighty = true
 		end
 		if percent <= 40 and not self.hitForty then
@@ -256,7 +256,7 @@ function module:CheckBossHealth()
 end
 
 function module:AddPhase()
-	self:Message(L["msg_addPhase"], "Attention", nil, "Alarm")
+	self:Message(L["msg_addPhase"], "Attention")
 	self:RemoveBar(L["bar_curseRift"])
 	self:RemoveBar(L["bar_overflowingHatredCast"])
 	if self.db.profile.addphase then

--- a/Raids/Naxxramas/Maexxna.lua
+++ b/Raids/Naxxramas/Maexxna.lua
@@ -1,6 +1,6 @@
 local module, L = BigWigs:ModuleDeclaration("Maexxna", "Naxxramas")
 
-module.revision = 30071
+module.revision = 30135
 module.enabletrigger = module.translatedName
 module.toggleoptions = { "cocoon", "webspray", "poison", "enrage", "spiderlings", "bosskill" }
 
@@ -32,7 +32,8 @@ L:RegisterTranslations("enUS", function()
 		trigger_cocoonGain = "(.+) is afflicted by Web Wrap.", --CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE // CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE
 		trigger_cocoonGainYou = "You are afflicted by Web Wrap.", --CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE
 		trigger_cocoonFade = "Web Wrap fades from (.+).", --CHAT_MSG_SPELL_AURA_GONE_OTHER // CHAT_MSG_SPELL_AURA_GONE_PARTY // CHAT_MSG_SPELL_AURA_GONE_SELF
-		bar_cocoonGain = "Cocoon ",
+		trigger_friendlyDeath = "(.+) dies.",
+		bar_cocoonGain = "Cocoon %s",
 		bar_cocoonCD = "Cocoon CD",
 
 		trigger_webSprayGain = "afflicted by Web Spray.", --CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE // CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE // CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE
@@ -108,9 +109,6 @@ function module:OnEnable()
 
 	self:RegisterEvent("CHAT_MSG_SPELL_PERIODIC_CREATURE_BUFFS", "Event") --trigger_enrageGain
 
-
-	self:ThrottleSync(0, syncName.cocoon)
-	self:ThrottleSync(0, syncName.cocoonFade)
 	self:ThrottleSync(8, syncName.webspray)
 	self:ThrottleSync(8, syncName.websprayFade)
 	self:ThrottleSync(2, syncName.poison)
@@ -159,13 +157,13 @@ end
 function module:Event(msg)
 	if string.find(msg, L["trigger_cocoonGain"]) then
 		local _, _, cocoonedPlayer, _ = string.find(msg, L["trigger_cocoonGain"])
-		self:Sync(syncName.cocoon .. " " .. cocoonedPlayer)
+		self:Sync(syncName.cocoon .. cocoonedPlayer) -- bake player into sync name to throttle per player
 	elseif msg == L["trigger_cocoonGainYou"] then
 		cocoonedPlayer = UnitName("Player")
-		self:Sync(syncName.cocoon .. " " .. cocoonedPlayer)
+		self:Sync(syncName.cocoon .. cocoonedPlayer)
 	elseif string.find(msg, L["trigger_cocoonFade"]) then
 		local _, _, cocoonedPlayerFade, _ = string.find(msg, L["trigger_cocoonFade"])
-		self:Sync(syncName.cocoonFade .. " " .. cocoonedPlayerFade)
+		self:Sync(syncName.cocoonFade .. cocoonedPlayerFade)
 
 
 	elseif string.find(msg, L["trigger_webSprayGain"]) then
@@ -183,12 +181,26 @@ function module:Event(msg)
 	end
 end
 
+function module:OnFriendlyDeath(msg)
+	local _, _, deadPlayer, _ = string.find(msg, L["trigger_friendlyDeath"])
+	if deadPlayer then
+		self:Sync(syncName.cocoonFade .. cocoonedPlayerFade)
+	end
+end
+
 function module:BigWigs_RecvSync(sync, rest)
-	if sync == syncName.cocoon and rest and self.db.profile.cocoon then
-		self:Cocoon(rest)
-	elseif sync == syncName.cocoonFade and rest and self.db.profile.cocoon then
-		self:CocoonFade(rest)
-	elseif sync == syncName.webspray and self.db.profile.webspray then
+	local _, _, cocoonPlayer = string.find(sync, syncName.cocoon .. "(.+)")
+	if cocoonPlayer and self.db.profile.cocoon then
+		self:Cocoon(cocoonPlayer)
+		return
+	end
+	local _, _, cocoonPlayer = string.find(sync, syncName.cocoonFade .. "(.+)")
+	if cocoonPlayer and self.db.profile.cocoon then
+		self:CocoonFade(cocoonPlayer)
+		return
+	end
+	
+	if sync == syncName.webspray and self.db.profile.webspray then
 		self:Webspray()
 	elseif sync == syncName.websprayFade then
 		self:WebsprayFade()
@@ -203,13 +215,13 @@ function module:BigWigs_RecvSync(sync, rest)
 	end
 end
 
-function module:Cocoon(rest)
+function module:Cocoon(player)
 	self:RemoveBar(L["bar_cocoonCD"])
-	self:Bar(L["bar_cocoonGain"] .. rest, timer.cocoonDuration, icon.cocoon, true, color.cocoon)
+	self:MonitorBar(string.format(L["bar_cocoonGain"], player), icon.cocoon, BigWigs:GetGUIDByName(player, 0))
 end
 
-function module:CocoonFade(rest)
-	self:RemoveBar(L["bar_cocoonGain"] .. rest)
+function module:CocoonFade(player)
+	self:RemoveBar(string.format(L["bar_cocoonGain"], player))
 end
 
 function module:Webspray()

--- a/Raids/Naxxramas/Thaddius.lua
+++ b/Raids/Naxxramas/Thaddius.lua
@@ -4,7 +4,7 @@ local stalagg = AceLibrary("Babble-Boss-2.2")["Stalagg"]
 
 module.revision = 30091
 module.enabletrigger = { module.translatedName, feugen, stalagg }
-module.toggleoptions = { "power", "magneticPull", "manaburn", "tankthreat", -1, "phase", -1, "enrage", "selfcharge", "polarity", "bosskill" }
+module.toggleoptions = { "addbars", "power", "magneticPull", "manaburn", "tankthreat", -1, "phase", -1, "enrage", "selfcharge", "polarity", "bosskill" }
 
 module.defaultDB = {
 	enrage = false,
@@ -15,6 +15,10 @@ module.defaultDB = {
 L:RegisterTranslations("enUS", function()
 	return {
 		cmd = "Thaddius",
+
+		addbars_cmd = "addbars",
+		addbars_name = "Health Bars for Adds",
+		addbars_desc = "Show health bars for Stalagg and Feugen",
 
 		power_cmd = "power",
 		power_name = "Power Surge Alert",
@@ -51,6 +55,9 @@ L:RegisterTranslations("enUS", function()
 
 		trigger_engage = "Stalagg crush you!", --CHAT_MSG_MONSTER_YELL
 		trigger_engage1 = "Feed you to master!", --CHAT_MSG_MONSTER_YELL
+
+		bar_feugen = "Feugen (R)",
+		bar_stalagg = "Stalagg (L)",
 
 		trigger_powerSurge = "Stalagg gains Power Surge.", --CHAT_MSG_SPELL_PERIODIC_CREATURE_BUFFS
 		bar_powerSurge = "Power Surge",
@@ -118,6 +125,7 @@ local timer = {
 local icon = {
 	powerSurge = "Spell_Shadow_UnholyFrenzy",
 	magneticPull = "spell_nature_groundingtotem",
+	add = "INV_Misc_Head_Undead_01",
 
 	phase2 = "Inv_misc_pocketwatch_01",
 
@@ -163,6 +171,11 @@ local syncName = {
 
 	polarityShiftCast = "ThaddiusPolarityShiftCast" .. module.revision,
 	polarity = "ThaddiusPolarity" .. module.revision,
+}
+
+local guid = {
+	feugen = nil,
+	stalagg = nil,
 }
 
 local phase2started = nil
@@ -221,15 +234,10 @@ function module:OnEngage()
 
 	stalaggDead = false
 	feugenDead = false
-
-	self.feugenHP = 100
-	self.stalaggHP = 100
-	self:TriggerEvent("BigWigs_StartHPBar", self, feugen, 100, "Interface\\Icons\\" .. icon.hpBar, true, color.hpBar)
-	self:TriggerEvent("BigWigs_SetHPBar", self, feugen, 0)
-	self:TriggerEvent("BigWigs_StartHPBar", self, stalagg, 100, "Interface\\Icons\\" .. icon.hpBar, true, color.hpBar)
-	self:TriggerEvent("BigWigs_SetHPBar", self, stalagg, 0)
-
-	self:ScheduleRepeatingEvent("CheckAddHP", self.CheckAddHP, 0.5, self)
+	
+	guid.stalagg = nil
+	guid.feugen = nil
+	self:FindAdds()
 
 	if self.db.profile.magneticPull then
 		self:Bar(L["bar_magneticPull"], timer.magneticPull, icon.magneticPull, true, color.magneticPull)
@@ -349,9 +357,9 @@ end
 function module:CHAT_MSG_COMBAT_HOSTILE_DEATH(msg)
 	BigWigs:CheckForBossDeath(msg, self)
 
-	if (msg == string.format(UNITDIESOTHER, "Feugen")) then
+	if (msg == string.format(UNITDIESOTHER, feugen)) then
 		feugenDead = true
-	elseif (msg == string.format(UNITDIESOTHER, "Stalagg")) then
+	elseif (msg == string.format(UNITDIESOTHER, stalagg)) then
 		stalaggDead = true
 	end
 
@@ -379,32 +387,6 @@ end
 function module:CHAT_MSG_RAID_BOSS_EMOTE(msg)
 	if msg == L["trigger_3sec"] then
 		self:Sync(syncName.teslaOverload)
-	end
-end
-
-function module:CheckAddHP()
-	local feugenHealth
-	local stalaggHealth
-
-	for i = 1, GetNumRaidMembers() do
-		if UnitName("Raid" .. i .. "Target") == feugen then
-			feugenHealth = math.ceil((UnitHealth("Raid" .. i .. "Target") / UnitHealthMax("Raid" .. i .. "Target")) * 100)
-		elseif UnitName("Raid" .. i .. "Target") == stalagg then
-			stalaggHealth = math.ceil((UnitHealth("Raid" .. i .. "Target") / UnitHealthMax("Raid" .. i .. "Target")) * 100)
-		end
-		if feugenHealth and stalaggHealth then
-			break
-		end
-	end
-
-	if feugenHealth then
-		self.feugenHP = feugenHealth
-		self:TriggerEvent("BigWigs_SetHPBar", self, feugen, 100 - self.feugenHP)
-	end
-
-	if stalaggHealth then
-		self.stalaggHP = stalaggHealth
-		self:TriggerEvent("BigWigs_SetHPBar", self, stalagg, 100 - self.stalaggHP)
 	end
 end
 
@@ -491,15 +473,38 @@ function module:ManaBurn()
 	self:Sound("Beware")
 end
 
+function module:FindAdds()
+	if not guid.feugen then
+		local temp = BigWigs:GetGUIDByName(feugen, 1)
+		if temp then
+			guid.feugen = temp
+			if self.db.profile.addbars then
+				self:MonitorBar(L["bar_feugen"], icon.add, temp)
+			end
+		end
+	end
+	if not guid.stalagg then
+		local temp = BigWigs:GetGUIDByName(stalagg, 1)
+		if temp then
+			guid.stalagg = temp
+			if self.db.profile.addbars then
+				self:MonitorBar(L["bar_stalagg"], icon.add, temp)
+			end
+		end
+	end
+	if not (guid.stalagg and guid.feugen) then
+		self:ScheduleEvent("ThaddiusAddLocator", self.FindAdds, 0.2, self) 
+	end
+end
+
 function module:Phase2()
 	phase2started = true
 
-	self:TriggerEvent("BigWigs_StopHPBar", self, feugen)
-	self:TriggerEvent("BigWigs_StopHPBar", self, stalagg)
-	self:CancelScheduledEvent("CheckAddHP")
 	self:CancelScheduledEvent("MagneticPull")
 	self:RemoveBar(L["bar_magneticPull"])
 	self:RemoveBar(L["bar_powerSurge"])
+	self:RemoveBar(L["bar_feugen"])
+	self:RemoveBar(L["bar_stalagg"])
 	self:CancelDelayedSound("Info")
 
 	self:Bar(L["bar_phase2"], timer.phase2, icon.phase2, true, color.phase)

--- a/documentation/API.txt
+++ b/documentation/API.txt
@@ -3,17 +3,23 @@
 modulePrototype API
 -------------------
 
-module:OnSetup()
-module:OnEngage()
-module:OnDisengage()
+module:OnEnable() -- called once when any module is enabled
+module:OnSetup() -- called when a boss module (not trash) is enabled or rebooted
+module:OnEngage() -- called on every fight start
+module:OnDisengage() -- called on reboot or disable
+-- boss modules only: wipes trigger a reboot, victories trigger a disable
+
+module:SendEngageSync()
+module:SendBossDeathSync()
 
 module:Sync(sync)
 module:DelayedSync(delay, sync)
 module:CancelDelayedSync(sync)
 module:ThrottleSync(throttle, sync)
 
-module:Message(text, priority, noRaidSay, sound, broadcastOnly)
-module:DelayedMessage(delay, text, priority, noRaidSay, sound, broadcastOnly)
+-- set sound to false for fully silent messages; setting noRaidSay to true prevents personal warnings from being pushed to /rw by the RaidWarn plugin; broadcastOnly is the obverse (no local action, only /rw if enabled through RaidWarn)
+module:Message(text, color, noRaidSay, sound, broadcastOnly)
+module:DelayedMessage(delay, text, color, noRaidSay, sound, broadcastOnly)
 module:CancelDelayedMessage(text)
 
 module:Bar(text, time, icon, otherColor, c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, emphasize, target, spell)
@@ -39,8 +45,8 @@ module:CancelDelayedSound(sound, id)
 module:Icon(name, iconnumber)
 module:RemoveIcon()
 
-module:WarningSign(icon, duration, force, text)
-module:RemoveWarningSign(icon, forceHide)
+module:WarningSign(icon, duration, force, text) -- forced overwrites existing signs (but cannot overwrite forced signs)
+module:RemoveWarningSign(icon, forceHide) -- forceHide clears everything
 module:DelayedWarningSign(delay, icon, duration, id)
 module:CancelDelayedWarningSign(icon, id)
 
@@ -49,15 +55,13 @@ module:Say(msg)
 module:Proximity()
 module:RemoveProximity()
 
-module:SetRaidTargetForPlayer(player, mark) -- mark can be index or name
+module:SetRaidTargetForPlayer(player, mark) -- mark can be index or capitalized name
 module:GetAvailableRaidMark(excludeMarks, reverse)
 module:RestorePreviousRaidTargetForPlayer(player)
 module:RestoreInitialRaidTargetForPlayer(player)
 
 module:OnEnemyDeath(msg) -- do not register CHAT_MSG_COMBAT_HOSTILE_DEATH
 module:OnFriendlyDeath(msg) -- do not register CHAT_MSG_COMBAT_FRIENDLY_DEATH
-
-module:SendBossDeathSync()
 
 
 ----------------
@@ -67,12 +71,112 @@ Helper Functions
 BigWigs:CancelAuraId(spellId) -- requires SuperWoW
 BigWigs:CancelAuraTexture(texture)
 BigWigs:BuffNameByIndex(buffIndex) -- returns localized name from tooltip
+BigWigs:BuffIsPresent(unitId, spellId) -- check UnitBuff(), return true or nil
+BigWigs:DebuffIsPresent(unitId, spellId) -- check UnitDebuff(), return true or nil
+BigWigs:AuraIsPresent(unitId, spellId) -- check both, return true or nil
+BigWigs:GetCastTimeCoefficient(unitId) -- return cast time multiplier based on presence of Curse of Tongues and Mind-numbing Poison on the unit
 
 -- depth (integer) specifies which units to scan (0 = raidN, 1 = raidNtarget, 2 = raidNtargettarget, etc). 
 BigWigs:GetUnitIdByName(name, depth) -- returns "raidN", "raidNtarget", etc
 BigWigs:GetTargetByName(name, depth) -- returns "targetName" of named unit
 BigWigs:GetGUIDByName(name, depth, ignoredGUIDs) -- ignoredGUIDs must be a table
-
 BigWigs:OffsetGUID(input, offset) -- adds offset (signed integer) to GUID string
 
-BigWigs:RaidTargetLookup(input) -- For string input (eg "star", "Circle", "none") returns raid target index for use with SetRaidTarget(unit, index). For integer input (eg 1, 8, nil) returns raid target name to translate the output of GetRaidTargetIndex(unit).
+BigWigs:RaidTargetLookup(input, colorize) -- For string input (eg "star", "Circle", "none") returns raid target index for use with SetRaidTarget(unit, index). For integer input (eg 1, 8, nil) returns raid target name to translate the output of GetRaidTargetIndex(unit); if colorize arg is provided, the name will be returned as a colorized string.
+
+BigWigs:FormatLargeNumber(integer) -- returns the 4 most significant digits as a string (eg "42", "3172", "80.93k", "143.2k", "2168k", "45.82m")
+
+BigWigs:GetHealthPercent(unitId, round) -- returns nil if unit does not exist
+
+
+----------------
+Available Colors
+----------------
+
+Message Colors - Plugins\Messages.lua & Plugins\Colors.lua
+--------------
+Messages sent by module:Message() default to white color. There are 3 ways of coloring them:
+
+A) Urgency Keywords
+You can use certain Keywords to access colors representing different levels of urgency, as provided by the Colors plugin. Keywords need to be capitalized. Below you can find the default values, but users can change them through the in-game menu at Plugins>Colors>Messages (which can be very important to color-blind people, so I suggest mostly sticking to Keywords to allow users customization):
+	Important = Red = "ff0000"
+	Personal = "ff0000"
+	Purple = "660099"
+	Urgent = Orange = "ff7f00"
+	Attention = Yellow = "ffff00"
+	Positive = Green = "00ff00"
+	Bosskill = "00ff00"
+	Core = Cyan = "00ffff"
+ex: self:Message("Hello World", "Urgent")
+
+B) RGB Tables
+The color argument of Message() accepts a table with 3 key-value pairs of r, g, b directly, where the value has to be a number between 0 and 1.
+ex: self:Message("Hello World", {r=1, g=0.5, b=0.5})
+
+C) PaintChips
+Colors that do not fit either of the above patterns (captialized keywords, RGB table) will be attempted to be resolved through the PaintChips library (see below).
+ex: self:Message("Hello World", "magenta")
+
+
+PaintChips - Libs\PaintChips-2.0\PaintChips-2.0.lua
+----------
+Colors are handled by the PaintChips library, so all new colors need to be registered with it for use with messages or bars. The Colors plugin offers an easy way to register custom colors on the fly via BigWigsColors:RegHex(hex) for use in a module's OnEnable().
+ex: BigWigsColors:RegHex("3366CC")
+
+PaintChips runs all incoming strings through string.lower(), so capitalization does not matter (both when registering and when recalling).
+
+Hardcoded colors in PaintChips:
+	white = "ffffff"
+	black = "000000"
+	blue = "0000ff"
+	magenta = "ff00ff"
+	cyan = "00ffff"
+	green = "00ff00"
+	yellow = "ffff00"
+	orange = "ff7f00"
+	red = "ff0000"
+
+PaintChips also makes colors from the client's UI available (note - addons may change these, below are only default values!):
+	DebuffTypeCurse = "9900ff"
+	DebuffTypeDisease = "996600"
+	DebuffTypeMagic = "3399ff"
+	DebuffTypePoison = "009900"
+	DebuffTypenone = "cc0000"
+
+	DRUID = "ff7d0a"
+	HUNTER = "abd473"
+	MAGE = "69ccf0"
+	PALADIN = "f58cba"
+	PRIEST = "ffffff"
+	ROGUE = "fff569"
+	SHAMAN = "2459ff" -- TBC (eg ShaguTweaks), unmodded 1.12 = same as paladin
+	WARLOCK = "9482c9"
+	WARRIOR = "c79c6e"
+
+	ItemQuality0 = ItemQualityPoor = "9d9d9d" -- grey
+	ItemQuality1 = ItemQualityCommon = "ffffff" -- white
+	ItemQuality2 = ItemQualityUncommon = "1eff00" -- green
+	ItemQuality3 = ItemQualityRare = "0070dd" -- dark blue
+	ItemQuality4 = ItemQualityEpic = "a335ee" -- purple
+	ItemQuality5 = ItemQualityLegendary = "ff8000" -- orange
+	ItemQuality6 = ItemQualityArtifact = "e6cc80" -- gold
+
+Plugins\Colors.lua registers hardcoded raid target (raid mark) colors:
+	unmarked = "bababa" -- light grey
+	Star = "ffff00" -- yellow
+	Circle = "ffa500" -- orange
+	Diamond = "ff20ff" -- purple
+	Triangle = "00ff00" -- green
+	Moon = "e0ffff" -- very light cyan
+	Square = "00baff" -- bright blue
+	Cross = "ff2020" -- red
+	Skull = "ffffff" -- white
+
+
+Color Utility Functions - Plugins\Colors.lua
+-----------------------
+BigWigsColors:RegHex(hex) -- hex can be a string or a table of strings
+BigWigsColors:RGBToHex(r, g, b) -- r/g/b are between 0 and 1, returns hex string
+BigWigsColors:ColorizeString(input, color) -- returns input string colorized
+
+

--- a/documentation/changelog.txt
+++ b/documentation/changelog.txt
@@ -2,6 +2,25 @@
 Changelog for BigWigs - Golden Edition
 --------------------------------------
 
+March Update - 2026-03-16 (Golden 30136)
+------------
+(AQ40) C'Thun - improved map coordinates (by DCV-2142), fixed rounding for tentacle HP announcement
+(Naxx) Maexxna - HP bars for Web Wrap victims, prevent sync spam
+(Naxx) Thaddius - switched to MonitorBars for Phase 1 adds
+(K40) Rupturan - added Fragment health bars, improved cast timers, earlier Window of Opportunity tracking (at 25%, up from 15%)
+(K40) Gnarlmoon - replaced Owl HP frame with MonitorBars, minor adjustments
+(K40) Chess - MC announce and HP bars, upcoming hide warning (8% HP), better Bishop scanning, shortened some messages and made Queen's Fury messages brighter
+(K40) adjusted lots of warning messages for a) sound (silenced some, adjusted others) and b) compatibility with the RaidWarn plugin (don't push personal warnings to /rw if enabled)
+
+(Core) new helper functions: BigWigs:FormatLargeNumber(integer), BigWigs:BuffIsPresent(unitId, spellId), BigWigs:DebuffIsPresent(unitId, spellId), BigWigs:AuraIsPresent(unitId, spellId), BigWigs:GetCastTimeCoefficient(unitId), BigWigs:GetHealthPercent(unitId, round); optional colorization for string output of BigWigs:RaidTargetLookup(input, colorize)
+(Bars) MonitorBar polish - shortened values, colored marks, dark background, performance improvement
+(Colors) added raid mark colors, new BigWigsColors:ColorizeString(input, color)
+(Sound) enabled "Hide" sound cue
+(Libs) additions to Babble Boss & Babble Zone (1.18, known 1.18.1 stuff)
+
+(CommonAuras) - fix for number sync at Fear Ward and Spirit Link (by pepopo978 and DCV-2142)
+
+
 February Update - 2026-03-01 (Golden 30135)
 ---------------
 (MC) Thaurissan - correct positioning is now recognized, added warning about upcoming floor zones recasts


### PR DESCRIPTION
* better map coordinates at C'Thun (by DCV-2142), fixed health rounding
* better bars at Maexxna and Thaddius P1
* Rupturan - Fragment health bars, better cast timers, earlier Window tracking
* Gnarlmoon - replaced Owl HP frame with MonitorBars, performance improvements
* Chess - MC announce and HP bars, upcoming hide warning, many small adjustments
* adjusted sound cues for K40 here and there
* MonitorBar polish (condensed HP values, colored raid marks, etc)
* lots of new helper functions and other internal changes
* fixed numbers showing up in Fear Ward and Spirit Link announcements (by pepopo978 and DCV-2142)