### PR TITLE
(Bars) MonitorBar fix - stable sorting of bars (no more random reordering)

### DIFF
--- a/BigWigs.toc
+++ b/BigWigs.toc
@@ -1,8 +1,8 @@
 ## Interface: 11200
 
-## X-Revision: 30136
+## X-Revision: 30137
 ## X-Fork: Golden
-## Title: |cFFEDD516Golden|r Big Wigs |cff7fff7f30136|r |cffabd473Turtle-WoW|r
+## Title: |cFFEDD516Golden|r Big Wigs |cff7fff7f30137|r |cffabd473Turtle-WoW|r
 ## Title-zhCN: |cffabd473Turtle-WoW|r Big Wigs
 ## Notes: Boss Mods with Timer bars.
 ## Notes-esES: Módulos para Jefes con barras temporizadoras.

--- a/Plugins/Bars.lua
+++ b/Plugins/Bars.lua
@@ -890,10 +890,13 @@ function BigWigsBars:BigWigs_StartMonitorBar(module, barName, icon, guid, type, 
 			monitorBarCache[i][3] = type
 			monitorBarCache[i][4] = displayText
 			monitorBarCache[i][5] = insertMark
+			-- vary endtime to guarantee stable sorting of bars created at the same time
+			candybar.var.handlers[id].endtime = candybar.var.handlers[id].endtime - 1 + i/10
 		end
 	end
 	if not barExists then
 		table.insert(monitorBarCache, { id, guid, type, displayText, insertMark })
+		candybar.var.handlers[id].endtime = candybar.var.handlers[id].endtime - 1 + table.getn(monitorBarCache)/10
 	end
 
 	BigWigsBars:UpdateAllMonitorBars()

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Updates are summarized in the [changelog](https://github.com/ElesionWoW/BigWigs/
 * Incantagos - target Affinities automatically or by clicking on the timer bar, Surge of Mana victim bars, Blizzard warning
 * Anomalus - Floor Zone warnings
 * Echo - additional warnings, optional timers to align Resto Pot usage
-* Chess - accurate cast bars (hide, SBV), Curse CD (to allign hide phases), MC announcements, hide pre-warning (HP based)
+* Chess - accurate cast bars (hide, SBV), Curse CD (to allign hide phases), MC announcements, hide pre-warning (HP based), Void Zone damage alerts
 * Sanv - bar for add phase duration, warn about last Curse before Feedback
 * Rupturan - Boulder target warnings, P1 kill window, alert when you stand in fire, monitoring of Felheart mana, Fragment health bars
 * Mephistroth - Doom bar, purge alert, better Shards handling, sound cue on Shackle fade
@@ -90,6 +90,7 @@ Relative to pepopo978's BigWigs.
 * "Dark Subservience on You" will also give a pre-warning based on Queen starting to cast, even if cast warnings are disabled.
 * Added audio feedback on King's Fury end and successful /bow.
 * Added Queen's Fury magnitude alerts showing stack count and rough tick damage (default: off).
+* Added personal alerts when taking Void Zone damage (default: on).
 ### Sanv Tas'dal
 * Added alerts for Portal Opening and Enrage (always on).
 * Added timer bar for add phase (default: on).

--- a/documentation/changelog.txt
+++ b/documentation/changelog.txt
@@ -2,6 +2,12 @@
 Changelog for BigWigs - Golden Edition
 --------------------------------------
 
+Bar Sorting Hotfix - 2026-03-18 (Golden 30137)
+------------------
+(Bars) MonitorBar - stable sorting of bars (no more random reordering)
+(K40) Chess - alerts on every Void Zone tick you take
+
+
 March Update - 2026-03-16 (Golden 30136)
 ------------
 (AQ40) C'Thun - improved map coordinates (by DCV-2142), fixed rounding for tentacle HP announcement


### PR DESCRIPTION
* MonitorBars have a stable order now. - Multiple MonitorBars started at the same time would constantly and randomly reorder themselves whenever another bar was started due to table.sort not providing stable results. Implemented a tiny timestamp offset for each bar to enforce a stable order. Big thanks to @DCV-2142 for reporting this issue and providing helpful feedback.
* Updated documentation and bumped version number.