### PR TITLE
(BWL) Ezzel - new module with Charge, Acid Bomb, Transmute to Gold mechanics

### DIFF
--- a/BigWigs.toc
+++ b/BigWigs.toc
@@ -1,8 +1,8 @@
 ## Interface: 11200
 
-## X-Revision: 30137
+## X-Revision: 30138
 ## X-Fork: Golden
-## Title: |cFFEDD516Golden|r Big Wigs |cff7fff7f30137|r |cffabd473Turtle-WoW|r
+## Title: |cFFEDD516Golden|r Big Wigs |cff7fff7f30138|r |cffabd473Turtle-WoW|r
 ## Title-zhCN: |cffabd473Turtle-WoW|r Big Wigs
 ## Notes: Boss Mods with Timer bars.
 ## Notes-esES: Módulos para Jefes con barras temporizadoras.
@@ -136,6 +136,7 @@ Raids\AQ40\Brainwasher.lua
 
 Raids\BWL\Chromaggus.lua
 Raids\BWL\Ebonroc.lua
+Raids\BWL\Ezzel.lua
 Raids\BWL\Firemaw.lua
 Raids\BWL\Flamegor.lua
 Raids\BWL\Nefarian.lua

--- a/Libs/Babble-Zone-2.2/Babble-Zone-2.2.lua
+++ b/Libs/Babble-Zone-2.2/Babble-Zone-2.2.lua
@@ -74,6 +74,7 @@ BabbleZone:RegisterTranslations("enUS", function()
 		["The Upper Necropolis"] = true,
 		["Thorn Gorge"] = true, --1.18.1 battleground
 		["Timbermaw Hold"] = true, --1.18.1
+		["Timbermaw Tunnels"] = true, --1.18.1
 		["Tower of Karazhan"] = true,
 		["Windhorn Canyon"] = true, --1.18.1
 		["Winter Veil Vale"] = true,

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # BigWigs Golden Edition
-Big updates to K40 and MC (**check your boss settings!**), small fixes and updates here and there. Mostly tested.
+Big updates to K40, BWL, and MC (**check your boss settings!**), small fixes and updates here and there. Mostly tested.
 
 Updates are summarized in the [changelog](https://github.com/ElesionWoW/BigWigs/blob/master/documentation/changelog.txt). Details are in individual commits.
 ## Karazhan 40 - Highlights
@@ -14,6 +14,7 @@ Updates are summarized in the [changelog](https://github.com/ElesionWoW/BigWigs/
 * Mephistroth - Doom bar, purge alert, better Shards handling, sound cue on Shackle fade
 ## Other Feature Highlights
 * Announcing bars to /raid now requires a Shift-click to prevent accidental spam.
+* BWL - new Ezzel Darkbrewer module, updates and 1.18.1 fixes for Nefarian, Razorgore, Flamegor, Broodlord Lashlayer
 * AQ40 - C'Thun map fix, vastly improved monitoring of Stomach Tentacles; improved map coordinates (by [DCV-2142](https://github.com/DCV-2142/BigWigs))
 * MC - warning about tank knockback at Ragnaros, improved information at Thaurissan
 * ZG & AQ20 - minor fixes

--- a/Raids/BWL/Ezzel.lua
+++ b/Raids/BWL/Ezzel.lua
@@ -1,0 +1,209 @@
+local module, L = BigWigs:ModuleDeclaration("Ezzel Darkbrewer", "Blackwing Lair")
+
+-- module variables
+module.revision = 30138
+module.enabletrigger = module.translatedName
+module.toggleoptions = { "charge", "chargemark", "acid", "transmute", "bosskill" }
+
+-- module defaults
+module.defaultDB = {
+	charge = true,
+	chargemark = true,
+	acid = true,
+	transmute = true,
+}
+
+-- localization
+L:RegisterTranslations("enUS", function()
+	return {
+		cmd = "EzzelDarkbrewer",
+
+		charge_cmd = "charge",
+		charge_name = "Charge Alert",
+		charge_desc = "Alerts about incoming Charges",
+
+		chargemark_cmd = "chargemark",
+		chargemark_name = "Charge Mark",
+		chargemark_desc = "Mark Charge victims with Triangle",
+
+		acid_cmd = "acid",
+		acid_name = "Acid Alert",
+		acid_desc = "Warns when you are standing in Acid",
+
+		transmute_cmd = "transmute",
+		transmute_name = "Transmute to Gold Alert",
+		transmute_desc = "Warns when the boss begins to cast Transmute to Gold (wipe mechanic)",
+
+		trigger_charge = "Raka begins charging (.+)!",
+		bar_charge = "Charge on %s",
+		say_charge = "Charge On Me!",
+		warn_charge = "HIDE",
+
+		trigger_acid = "You suffer (.+) damage from Ezzel Darkbrewer's Acid Bomb",
+		warn_acid = "ACID - MOVE",
+
+		trigger_transmute = "Ezzel Darkbrewer begins to cast Transmute to Gold",
+		bar_transmute = "Kill Boss",
+	}
+end)
+
+-- timer and icon variables
+local timer = {
+	charge = 8,
+	transmute = 8,
+}
+
+local icon = {
+	charge = "ABILITY_MOUNT_MOUNTAINRAM",
+	acid = "ABILITY_CREATURE_POISON_06",
+	transmute = "SPELL_HOLY_HARMUNDEADAURA",
+}
+
+local syncName = {
+	charge = "EzzelCharge" .. module.revision,
+	transmute = "EzzelTransmute" .. module.revision,
+}
+
+local guid = {
+	ezzel = "0xF13000FE7C279933",
+}
+
+function module:OnEnable()
+	--self:RegisterEvent("CHAT_MSG_SPELL_PERIODIC_FRIENDLYPLAYER_DAMAGE", "AfflictionEvent")
+	--self:RegisterEvent("CHAT_MSG_SPELL_PERIODIC_PARTY_DAMAGE", "AfflictionEvent")
+	self:RegisterEvent("CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE", "AfflictionEvent")
+
+	self:RegisterEvent("CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE", "CastEvent")
+	self:RegisterEvent("CHAT_MSG_SPELL_CREATURE_VS_CREATURE_BUFF", "CastEvent")
+	
+	--self:RegisterEvent("CHAT_MSG_MONSTER_YELL")
+	self:RegisterEvent("CHAT_MSG_RAID_BOSS_EMOTE")
+
+	self:ThrottleSync(3, syncName.charge)
+	self:ThrottleSync(3, syncName.transmute)
+end
+
+function module:OnSetup()
+end
+
+function module:OnEngage()	
+	-- Start health monitoring
+	--self:ScheduleRepeatingEvent("CheckBossHealth", self.CheckBossHealth, 0.5, self)
+end
+
+function module:OnDisengage()
+end
+
+function module:AfflictionEvent(msg)
+	if self.db.profile.acid and string.find(msg, L["trigger_acid"]) then
+		self:Sound("Info")
+		self:WarningSign(icon.acid, 1, false, L["warn_acid"])
+	end
+end
+
+function module:CastEvent(msg)
+	if string.find(msg, L["trigger_transmute"]) then
+		self:Sync(syncName.transmute)
+	end
+end
+
+function module:CHAT_MSG_MONSTER_YELL(msg)
+end
+
+function module:CHAT_MSG_RAID_BOSS_EMOTE(msg)
+	local _, _, player = string.find(msg, L["trigger_charge"])
+	if player then
+		self:Sync(syncName.charge .. " " .. player)
+	end
+end
+
+function module:BigWigs_RecvSync(sync, rest, nick)
+	if sync == syncName.transmute then
+		self:TransmuteToGold()
+	elseif sync == syncName.charge and rest then
+		self:Charge(rest)
+	end
+end
+
+function module:TransmuteToGold()
+	if not self.db.profile.transmute then return end
+
+	self:Bar(L["bar_transmute"], timer.transmute * BigWigs:GetCastTimeCoefficient(guid.ezzel), icon.transmute)
+	self:Sound("Beware")
+end
+
+function module:Charge(player)
+	if self.db.profile.charge then
+		self:Bar(string.format(L["bar_charge"],player), timer.charge, icon.charge)
+		if player == UnitName("player") then
+			self:WarningSign(icon.charge, 4, true, L["warn_charge"])
+			self:Sound("RunAway")
+			SendChatMessage(L["say_charge"], "SAY")
+		else
+			self:Sound("Alarm")
+		end
+	end
+
+	if self.db.profile.chargemark then
+		self:SetRaidTargetForPlayer(player, "Triangle")
+		self:ScheduleEvent("RemoveChargeMark", self.RestoreInitialRaidTargetForPlayer, 8, self, player)
+	end
+end
+
+function module:Test()
+	self:Engage()
+	
+	-- test characters
+	local player = UnitName("player")
+	local raid1 = UnitName("raid1") or "Raid1"
+	local raid2 = UnitName("raid2") or "Raid2"
+	
+	local events = {
+		-- Acid
+		{ time = 2, func = function()
+			local msg = "You suffer 450 Nature damage from Ezzel Darkbrewer's Acid Bomb."
+			print("Test: " .. msg)
+			self:TriggerEvent("CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE", msg)
+		end },
+		{ time = 3, func = function()
+			local msg = "You suffer 0 Nature damage from Ezzel Darkbrewer's Acid Bomb. (405 absorbed)"
+			print("Test: " .. msg)
+			self:TriggerEvent("CHAT_MSG_SPELL_PERIODIC_SELF_DAMAGE", msg)
+		end },
+
+		-- Charge
+		{ time = 8, func = function()
+			local msg = "Ton'Raka begins charging "..raid1.."!"
+			print("Test: " .. msg)
+			self:TriggerEvent("CHAT_MSG_RAID_BOSS_EMOTE", msg)
+		end },		
+		{ time = 18, func = function()
+			local msg = "Ton'Raka begins charging "..player.."!"
+			print("Test: " .. msg)
+			self:TriggerEvent("CHAT_MSG_RAID_BOSS_EMOTE", msg)
+		end },
+
+		-- Transmute
+		{ time = 28, func = function()
+			local msg = "Ezzel Darkbrewer begins to cast Transmute to Gold."
+			print("Test: " .. msg)
+			self:TriggerEvent("CHAT_MSG_SPELL_CREATURE_VS_CREATURE_DAMAGE", msg)
+		end },
+
+		-- End of Test
+		{ time = 38, func = function()
+			print("Test: Disengage")
+			module:Disengage()
+		end },
+	}
+	
+	-- Schedule each event
+	for i, event in ipairs(events) do
+		self:ScheduleEvent("EzzelTest" .. i, event.func, event.time)
+	end
+
+	self:Message(module.translatedName .. " test started", "Positive")
+	return true
+end
+
+-- Test command: /run BigWigs:GetModule("Ezzel Darkbrewer"):Test()

--- a/documentation/changelog.txt
+++ b/documentation/changelog.txt
@@ -2,6 +2,16 @@
 Changelog for BigWigs - Golden Edition
 --------------------------------------
 
+BWL Update 1 - 2026-03-24 (Golden 30138)
+------------
+(BWL) Razorgore - fixed egg count
+(BWL) Broodlord - added Serrated Wound mechanic, Mortal Strike click-to-target
+(BWL) Flamegor - added Overbearing Rage mechanic
+(BWL) Nefarian - fix class calls, other improvements
+(BWL) Ezzel - new module with Charge, Acid Bomb, Transmute to Gold mechanics
+(Lib) Babble-Zone - added Timbermaw Tunnels
+
+
 Bar Sorting Hotfix - 2026-03-18 (Golden 30137)
 ------------------
 (Bars) MonitorBar - stable sorting of bars (no more random reordering)


### PR DESCRIPTION
(BWL) Ezzel - added new module
* Warn when standing in floor Acid (default: on).
* Warn about incoming Charges (default: on) and mark the target (default: on).
* Timer bar for Transmute death race (default: on).
* Added test sequence.
To do: Figure out what applies and removes Chemical Rage and how to warn about it.
(TOC) added Ezzel module, bumped version number
(Documentation) updated changelog & README
(Lib) Babble-Zone - added Timbermaw Tunnels